### PR TITLE
Always include category 8000

### DIFF
--- a/lib/clients/prowlarr.py
+++ b/lib/clients/prowlarr.py
@@ -28,9 +28,9 @@ class Prowlarr:
                 query = (
                     f"{query}{{Season:{int(season):02}}}{{Episode:{int(episode):02}}}"
                 )
-                url = f"{self.host}/api/v1/search?query={query}&categories=5000&type=tvsearch"
+                url = f"{self.host}/api/v1/search?query={query}&categories=5000&categories=8000&type=tvsearch"
             elif mode == "movie":
-                url = f"{self.host}/api/v1/search?query={query}&categories=2000"
+                url = f"{self.host}/api/v1/search?query={query}&categories=2000&categories=8000"
             elif mode == "multi":
                 url = f"{self.host}/api/v1/search?query={query}"
             if indexers:


### PR DESCRIPTION
For indexers that do not support categories (Such as BitSearch)