### PR TITLE
TV Show titles and indexer results improvements

### DIFF
--- a/lib/utils/seasons.py
+++ b/lib/utils/seasons.py
@@ -80,14 +80,14 @@ def show_episode_info(tv_name, season, ids, mode, media_type):
         air_date = ep.air_date
         duration = ep.runtime
         tv_data = f"{ep_name}(^){episode}(^){season}"
-
+        label = f"{season}x{episode}. {ep_name}"
         still_path = ep.get("still_path", "")
         if still_path:
             poster = TMDB_POSTER_URL + still_path
         else:
             poster = fanart_data.get("fanart", "") if fanart_data else ""
 
-        list_item = ListItem()
+        list_item = ListItem(label=label)
 
         set_media_infotag(
             list_item,

--- a/lib/utils/seasons.py
+++ b/lib/utils/seasons.py
@@ -77,7 +77,6 @@ def show_episode_info(tv_name, season, ids, mode, media_type):
     for ep in season_details.episodes:
         ep_name = ep.name
         episode = ep.episode_number
-        label = f"{season}x{episode}. {ep_name}"
         air_date = ep.air_date
         duration = ep.runtime
         tv_data = f"{ep_name}(^){episode}(^){season}"
@@ -88,14 +87,16 @@ def show_episode_info(tv_name, season, ids, mode, media_type):
         else:
             poster = fanart_data.get("fanart", "") if fanart_data else ""
 
-        list_item = ListItem(label=label)
+        list_item = ListItem()
 
         set_media_infotag(
             list_item,
             mode,
             tv_name,
             ep.overview,
+            season=season,
             episode=episode,
+            ep_name=ep_name,
             duration=duration,
             air_date=air_date,
             ids=ids,

--- a/lib/utils/utils.py
+++ b/lib/utils/utils.py
@@ -710,7 +710,8 @@ def pre_process(res, mode, episode_name, episode, season):
     res = remove_duplicate(res)
     if get_setting("indexer") == Indexer.TORRENTIO:
         res = filter_by_torrentio_provider(res)
-    if mode == "tv" and get_setting("torrentio_filter_by_episode"):
+    if mode == "tv" and (get_setting("indexer") != Indexer.TORRENTIO or get_setting("torrentio_filter_by_episode")):
+        # do not filter by episode if torrentio is the indexer and the setting is disabled
         res = filter_by_episode(res, episode_name, episode, season)
     res = filter_by_quality(res)
     return res

--- a/lib/utils/utils.py
+++ b/lib/utils/utils.py
@@ -356,6 +356,7 @@ def set_media_infotag(
         info_tag.setFilenameAndPath(url)
     else:
         info_tag.setMediaType("episode")
+        info_tag.setTvShowTitle(name)
         info_tag.setFilenameAndPath(url)
         if air_date:
             info_tag.setFirstAired(air_date)
@@ -363,13 +364,8 @@ def set_media_infotag(
             info_tag.setSeason(int(season))
         if episode:
             info_tag.setEpisode(int(episode))
-            title = f"{name}"
-            if season and episode:
-                title += f" {season}x{episode}"
-            if ep_name:
-                title += f". {ep_name}"
-
-            info_tag.setTvShowTitle(title)
+        if ep_name:
+            info_tag.setTitle(ep_name)
         else:
             info_tag.setTitle(name)
             

--- a/lib/utils/utils.py
+++ b/lib/utils/utils.py
@@ -710,8 +710,7 @@ def pre_process(res, mode, episode_name, episode, season):
     res = remove_duplicate(res)
     if get_setting("indexer") == Indexer.TORRENTIO:
         res = filter_by_torrentio_provider(res)
-    if mode == "tv" and (get_setting("indexer") != Indexer.TORRENTIO or get_setting("torrentio_filter_by_episode")):
-        # do not filter by episode if torrentio is the indexer and the setting is disabled
+    if mode == "tv" and get_setting("filter_by_episode"):
         res = filter_by_episode(res, episode_name, episode, season)
     res = filter_by_quality(res)
     return res

--- a/lib/utils/utils.py
+++ b/lib/utils/utils.py
@@ -356,15 +356,6 @@ def set_media_infotag(
         info_tag.setFilenameAndPath(url)
     else:
         info_tag.setMediaType("episode")
-        info_tag.setTitle(name)
-
-        showTitle = f"{name}"
-        if season and episode:
-            showTitle += f" {season}x{episode}"
-        if ep_name:
-            showTitle += f". {ep_name}"
-
-        info_tag.setTvShowTitle(showTitle)
         info_tag.setFilenameAndPath(url)
         if air_date:
             info_tag.setFirstAired(air_date)
@@ -372,6 +363,16 @@ def set_media_infotag(
             info_tag.setSeason(int(season))
         if episode:
             info_tag.setEpisode(int(episode))
+            title = f"{name}"
+            if season and episode:
+                title += f" {season}x{episode}"
+            if ep_name:
+                title += f". {ep_name}"
+
+            info_tag.setTvShowTitle(title)
+        else:
+            info_tag.setTitle(name)
+            
 
     info_tag.setPlot(overview)
     if duration:

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -311,9 +311,6 @@ msgctxt "#30709"
 msgid "Drop torrent"
 msgstr ""
 
-
-
-
-
-
-
+msgctxt "#30710"
+msgid "Filter TV Shows by Season and Episode"
+msgstr ""

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -298,3 +298,7 @@ msgstr "Parar"
 msgctxt "#30709"
 msgid "Drop torrent"
 msgstr "Drop torrent"
+
+msgctxt "#30710"
+msgid "Filter TV Shows by Season and Episode"
+msgstr "Filtrar programas de TV por temporada e episódio"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -299,7 +299,6 @@ msgctxt "#30709"
 msgid "Drop torrent"
 msgstr "Drop torrent"
 
-
-
-
-
+msgctxt "#30710"
+msgid "Filter TV Shows by Season and Episode"
+msgstr "Filtrar programas de TV por temporada e episódio"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -298,3 +298,7 @@ msgstr ""
 msgctxt "#30709"
 msgid "Drop torrent"
 msgstr "Drop torrent"
+
+msgctxt "#30710"
+msgid "Filter TV Shows by Season and Episode"
+msgstr "Filtrar programas de TV por temporada y episodio"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -17,13 +17,13 @@
     </category>
     <category label="30020">
         <setting id="indexer" type="labelenum" label="30021" values="Torrentio|Burst|Jackett|Prowlarr|MediaFusion|Elfhosted|Zilean|Jackgram" default="Torrentio"/>
+        <setting id="filter_by_episode" type="bool" label="30710" default="true"/>
         <setting label="Torrentio Configuration" type="lsep"/>
         <setting id="torrentio_host" type="text" label="30025" default="https://torrentio.strem.fun/"/>
         <setting id="torrentio_desc_length" type="number" label="30026" default="100"/>
         <setting id="torrentio_results_per_page" type="number" label="30029" default="60"/>
         <setting id="torrentio_sort_by" type="labelenum" label="30028" values="Seeds|Size|Quality|Cached|None" default="None"/>
         <setting id="torrentio_priority_lang" type="labelenum" label="Priority Language" values="GB|JP|RU|IT|PT|ES|MX|KR|CN|TW|FR|DE|NL|IN|PL|LT|CZ|SK|SI|HU|RO|HR|UA|GR|DK|FI|SE|NO|TR|None" default="None"/>
-        <setting id="torrentio_filter_by_episode" type="bool" label="Filter by Season and Episode" default="true" help="If enabled the torrentio results will be filtered to get results that contain the specific season and episode of the selected item"/>
         <setting type="text" label="Click below to select torrentio providers" enable="false" visible="true" /> 
         <setting type="action" label="Torrentio Providers" action="RunPlugin(plugin://plugin.video.jacktook/?action=torrentio_selection)"/>
         <setting label="Jackgram Configuration" type="lsep"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -23,6 +23,7 @@
         <setting id="torrentio_results_per_page" type="number" label="30029" default="60"/>
         <setting id="torrentio_sort_by" type="labelenum" label="30028" values="Seeds|Size|Quality|Cached|None" default="None"/>
         <setting id="torrentio_priority_lang" type="labelenum" label="Priority Language" values="GB|JP|RU|IT|PT|ES|MX|KR|CN|TW|FR|DE|NL|IN|PL|LT|CZ|SK|SI|HU|RO|HR|UA|GR|DK|FI|SE|NO|TR|None" default="None"/>
+        <setting id="torrentio_filter_by_episode" type="bool" label="Filter by Season and Episode" default="true" help="If enabled the torrentio results will be filtered to get results that contain the specific season and episode of the selected item"/>
         <setting type="text" label="Click below to select torrentio providers" enable="false" visible="true" /> 
         <setting type="action" label="Torrentio Providers" action="RunPlugin(plugin://plugin.video.jacktook/?action=torrentio_selection)"/>
         <setting label="Jackgram Configuration" type="lsep"/>


### PR DESCRIPTION
This pull request introduces improvements to enhance the experience and in some cases showing more results from indexers.

Key Changes:
	1.	Improved Display Data:
Updated the displayed data for TV Shows seasons and episodes to ensure proper and accurate information is shown.
	2.	Optional Regex Filter:
Added a setting to disable the regex filter used to locate specific seasons and episodes in results. This prevents issues where the filter leads to no results being returned.
	3.	Prioritized Language Sorting:
When a prioritized language is set, sorting now ensures these results are placed at the top, while still applying sorting to all available results. The non-prioritized results are not discarded if the sorting key is set to none.
	4.	Optimized Results Limitation:
Moved the application of the results limiter to occur after sorting, eliminating less relevant entries and retaining higher-ranked results.

Purpose and Impact

The goal of these changes is to improve the functionality and usability when working in my setup with Torrentio and Elementum on the Arctic Horizon 2 skin.

Feedback Request

Feedback is highly encouraged to identify potential issues or improvements, especially regarding compatibility with other setups.