### PR TITLE
Original name, thumb art, duration fixes

### DIFF
--- a/lib/tmdb.py
+++ b/lib/tmdb.py
@@ -288,10 +288,12 @@ def show_items(res, mode, submode=None):
         air_date=release_date,
         duration=duration,
         ids=ids,
+        original_name=res.get("original_name", ""),
     )
 
     list_item.setArt(
         {
+            "thumb": poster_path,
             "poster": poster_path,
             "fanart": backdrop_path,
             "icon": os.path.join(ADDON_PATH, "resources", "img", "trending.png"),
@@ -425,6 +427,7 @@ def show_anime_results(res, mode):
         title,
         description,
         duration=duration,
+        original_name=res.get("original_name", ""),
     )
 
     if mode == "tv":

--- a/lib/utils/utils.py
+++ b/lib/utils/utils.py
@@ -342,21 +342,19 @@ def set_media_infotag(
     duration="",
     air_date="",
     url="",
+    original_name=""
 ):
     info_tag = list_item.getVideoInfoTag()
     info_tag.setPath(url)
-
+    info_tag.setTitle(name)
+    info_tag.setOriginalTitle(original_name if original_name else name)
     if mode == "movies":
         info_tag.setMediaType("movie")
-        info_tag.setTitle(name)
-        info_tag.setOriginalTitle(name)
     elif mode == "multi":
         info_tag.setMediaType("video")
-        info_tag.setTitle(name)
         info_tag.setFilenameAndPath(url)
     else:
         info_tag.setMediaType("episode")
-        info_tag.setTvShowTitle(name)
         info_tag.setFilenameAndPath(url)
         if air_date:
             info_tag.setFirstAired(air_date)
@@ -372,7 +370,7 @@ def set_media_infotag(
 
     info_tag.setPlot(overview)
     if duration:
-        info_tag.setDuration(int(duration))
+        info_tag.setDuration(int(duration)*60)
     if ids:
         tmdb_id, tvdb_id, imdb_id = ids.split(", ")
         info_tag.setIMDBNumber(imdb_id)


### PR DESCRIPTION
1.	Original Name Set in VideoInfoTag from TMDB Results
	•	The original title is now included in the VideoInfoTag from TMDB data.
	•	This enhancement allows some skins to display the original title and lays the groundwork for future functionality, such as searching indexers using both localized and original titles.
	•	This is particularly useful in cases where localized titles yield no results, but sources might still be available under the original title. For example, Torrentio often includes original titles in its results (from a search in a localized title), whereas Jackett typically does not.

2.	Thumbnail Handling in Multi-Mode Search Results
	•	Set the art thumb for search results in multi-mode.
	•	The thumb attribute takes precedence over the icon.
	•	Previously, all results would display the same icon, leading to a less intuitive browsing experience.

3.	Duration Format Conversion
	•	Corrected the duration format obtained from TMDB or Trakt.
	•	While TMDB and Trakt provide durations in minutes, Kodi requires durations in seconds.
	•	A simple conversion is now applied to ensure the interfaces display the correct runtime.