### PR TITLE
Deal with urls that redirect to a magnet

### DIFF
--- a/lib/gui/resolver_window.py
+++ b/lib/gui/resolver_window.py
@@ -4,6 +4,7 @@ from lib.play import get_playback_info
 from lib.utils.debrid_utils import get_pack_info
 from lib.utils.kodi_utils import ADDON_PATH
 from lib.utils.utils import Indexer, info_hash_to_magnet
+from lib.utils.resolve_to_magnet import resolve_to_magnet
 
 
 class ResolverWindow(BaseWindow):
@@ -56,10 +57,13 @@ class ResolverWindow(BaseWindow):
                 magnet = info_hash_to_magnet(guid)
             else:
                 magnet = guid if guid and guid.startswith("magnet:?") else ""
-
             if url.startswith("magnet:?") and not magnet:
                 magnet = url
                 url = ""
+
+            if not magnet:
+                magnet = resolve_to_magnet(url) or ""
+                
             is_torrent = True
         elif type == "Direct":
             url = self.source.get("downloadUrl")

--- a/lib/play.py
+++ b/lib/play.py
@@ -16,7 +16,7 @@ from lib.utils.utils import (
     torrent_clients,
 )
 from xbmcgui import Dialog
-
+from lib.utils.resolve_to_magnet import resolve_to_magnet
 
 def get_playback_info(data):
     title = data.get("title", "")
@@ -102,6 +102,9 @@ def get_elementum_url(magnet, url, mode, ids):
     else:
         tmdb_id = ""
     
+    if not magnet:
+        magnet = resolve_to_magnet(url) or ""
+    
     uri = magnet or url or ""
     return f"plugin://plugin.video.elementum/play?uri={quote(uri)}&type={mode}&tmdb={tmdb_id}"
 
@@ -110,6 +113,10 @@ def get_jacktorr_url(magnet, url):
     if not is_jacktorr_addon():
         notification(translation(30253))
         return
+    
+    if not magnet:
+        magnet = resolve_to_magnet(url) or ""
+
     if magnet:
         _url = f"plugin://plugin.video.jacktorr/play_magnet?magnet={quote(magnet)}"
     else:
@@ -121,6 +128,10 @@ def get_torrest_url(magnet, url):
     if not is_torrest_addon():
         notification(translation(30250))
         return
+
+    if not magnet:
+        magnet = resolve_to_magnet(url) or ""
+
     if magnet:
         _url = f"plugin://plugin.video.torrest/play_magnet?magnet={quote(magnet)}"
     else:

--- a/lib/play.py
+++ b/lib/play.py
@@ -16,7 +16,6 @@ from lib.utils.utils import (
     torrent_clients,
 )
 from xbmcgui import Dialog
-from lib.utils.resolve_to_magnet import resolve_to_magnet
 
 def get_playback_info(data):
     title = data.get("title", "")
@@ -102,9 +101,6 @@ def get_elementum_url(magnet, url, mode, ids):
     else:
         tmdb_id = ""
     
-    if not magnet:
-        magnet = resolve_to_magnet(url) or ""
-    
     uri = magnet or url or ""
     return f"plugin://plugin.video.elementum/play?uri={quote(uri)}&type={mode}&tmdb={tmdb_id}"
 
@@ -113,9 +109,6 @@ def get_jacktorr_url(magnet, url):
     if not is_jacktorr_addon():
         notification(translation(30253))
         return
-    
-    if not magnet:
-        magnet = resolve_to_magnet(url) or ""
 
     if magnet:
         _url = f"plugin://plugin.video.jacktorr/play_magnet?magnet={quote(magnet)}"
@@ -128,9 +121,6 @@ def get_torrest_url(magnet, url):
     if not is_torrest_addon():
         notification(translation(30250))
         return
-
-    if not magnet:
-        magnet = resolve_to_magnet(url) or ""
 
     if magnet:
         _url = f"plugin://plugin.video.torrest/play_magnet?magnet={quote(magnet)}"

--- a/lib/play.py
+++ b/lib/play.py
@@ -17,6 +17,7 @@ from lib.utils.utils import (
 )
 from xbmcgui import Dialog
 
+
 def get_playback_info(data):
     title = data.get("title", "")
     mode = data.get("mode", "")
@@ -109,7 +110,6 @@ def get_jacktorr_url(magnet, url):
     if not is_jacktorr_addon():
         notification(translation(30253))
         return
-
     if magnet:
         _url = f"plugin://plugin.video.jacktorr/play_magnet?magnet={quote(magnet)}"
     else:
@@ -121,7 +121,6 @@ def get_torrest_url(magnet, url):
     if not is_torrest_addon():
         notification(translation(30250))
         return
-
     if magnet:
         _url = f"plugin://plugin.video.torrest/play_magnet?magnet={quote(magnet)}"
     else:

--- a/lib/utils/resolve_to_magnet.py
+++ b/lib/utils/resolve_to_magnet.py
@@ -1,0 +1,32 @@
+import requests
+
+def resolve_to_magnet(url):
+    """
+    Perform a GET request to the URL and check if it redirects to a magnet
+    
+    Args:
+        url (str): The URL to check.
+    
+    Returns:
+        str: The magnet URL if the URL points or redirects to a magnet
+        
+    """
+    if url.startswith('magnet:?'):
+        return True
+
+    try:
+        response = requests.get(url, allow_redirects=False, stream=True)
+        is_redirect = response.is_redirect or response.is_permanent_redirect
+        redirect_location = response.headers.get('Location') if is_redirect else None
+        
+        if is_redirect and redirect_location.startswith('magnet:?'):
+            return redirect_location
+    except requests.RequestException as e:
+        return None
+    finally:
+        try:
+            response.close()
+        except NameError:
+            pass # Response not defined if an exception occurred before the request
+
+    return None

--- a/lib/utils/resolve_to_magnet.py
+++ b/lib/utils/resolve_to_magnet.py
@@ -1,4 +1,5 @@
 import requests
+from lib.utils.utils import USER_AGENT_HEADER
 
 def resolve_to_magnet(url):
     """
@@ -15,7 +16,7 @@ def resolve_to_magnet(url):
         return url
 
     try:
-        response = requests.get(url, allow_redirects=False, stream=True)
+        response = requests.get(url, headers=USER_AGENT_HEADER, timeout=10, allow_redirects=False, stream=True)
         is_redirect = response.is_redirect or response.is_permanent_redirect
         redirect_location = response.headers.get('Location') if is_redirect else None
         

--- a/lib/utils/resolve_to_magnet.py
+++ b/lib/utils/resolve_to_magnet.py
@@ -12,7 +12,7 @@ def resolve_to_magnet(url):
         
     """
     if url.startswith('magnet:?'):
-        return True
+        return url
 
     try:
         response = requests.get(url, allow_redirects=False, stream=True)


### PR DESCRIPTION
Most players accept either a direct URL or a magnet link, but the type must be specified beforehand. However, if a URL redirects to a magnet link, many players fail to handle the situation correctly. They attempt to fetch the redirected magnet link using standard HTTP clients, which are not equipped to process magnet links.

For example:
	•	Elementum: An open issue has been present since 2018 requesting support for shortened magnets that rely on redirection mechanisms (e.g., URLs redirecting to magnets). However, as the project is no longer actively maintained, this issue remains unresolved. [Elements Issue #305](https://github.com/elgatito/plugin.video.elementum/issues/305)
	•	Jacktorr: Exhibits the same issue, where magnet links after redirection are not handled properly.

Challenges:

It’s not trivial to determine whether a download link provided by an indexer is:
	1.	A direct torrent URL.
	2.	A URL redirecting to a magnet link.

For example, when using Jackett, all download links are returned as redirection links to the Jackett service itself. These links dynamically resolve to either a torrent file or a magnet link, depending on the provider, making it difficult to distinguish their nature upfront.

Solution:

This pull request introduces functionality to resolve redirection links before sending them to the player. If the provided URL redirects to a magnet link, the redirection will be followed, and the resolved magnet link will be passed to the player. This ensures compatibility with players that cannot handle redirection to magnets on their own.