### PR TITLE
Fix burst missing url

### DIFF
--- a/lib/gui/resolver_window.py
+++ b/lib/gui/resolver_window.py
@@ -56,7 +56,14 @@ class ResolverWindow(BaseWindow):
             if indexer in {Indexer.TORRENTIO, Indexer.ELHOSTED, Indexer.ZILEAN}:
                 magnet = info_hash_to_magnet(guid)
             else:
-                magnet = guid if guid and guid.startswith("magnet:?") else ""
+                if guid and guid.startswith("magnet:?"):
+                    magnet = guid
+                elif indexer == Indexer.BURST:
+                    url = guid
+                    magnet = ""
+                else:
+                    magnet = ""
+
             if url.startswith("magnet:?") and not magnet:
                 magnet = url
                 url = ""


### PR DESCRIPTION
The Burst indexer occasionally returns a URL instead of a magnet link, a scenario that is currently not handled. This update ensures that the Burst indexer can process and play results from providers such as RuTracker.

Closes: #83 