### PR TITLE
update settings.xml to the new format. Add language and region selection for TMDB

### DIFF
--- a/lib/navigation.py
+++ b/lib/navigation.py
@@ -48,6 +48,8 @@ from lib.tmdb import (
     tmdb_search_genres,
     tmdb_search_year,
 )
+from lib.utils.tmdb_consts import LANGUAGES
+
 from lib.db.cached import cache
 
 from lib.utils.utils import (
@@ -119,11 +121,13 @@ if JACKTORR_ADDON:
 tmdb = TMDb()
 tmdb.api_key = get_setting("tmdb_apikey", "b70756b7083d9ee60f849d82d94a0d80")
 
-if get_setting("kodi_language"):
-    kodi_lang = getLanguage(ISO_639_1)
-else:
-    kodi_lang = "en"
-tmdb.language = kodi_lang
+try:
+    language_index = get_setting("language")
+    tmdb.language = LANGUAGES[int(language_index)]
+except IndexError:
+    tmdb.language = "en-US"
+except ValueError:
+    tmdb.language = "en-US"
 
 
 def root_menu():

--- a/lib/utils/tmdb_consts.py
+++ b/lib/utils/tmdb_consts.py
@@ -1,0 +1,8 @@
+LANGUAGES = [
+    'ar-AE', 'ar-SA', 'be-BY', 'bg-BG', 'bn-BD', 'ca-ES', 'ch-GU', 'cs-CZ', 'da-DK', 'de-AT', 'de-CH',
+    'de-DE', 'el-GR', 'en-AU', 'en-CA', 'en-GB', 'en-IE', 'en-NZ', 'en-US', 'eo-EO', 'es-ES', 'es-MX',
+    'et-EE', 'eu-ES', 'fa-IR', 'fi-FI', 'fr-CA', 'fr-FR', 'gl-ES', 'he-IL', 'hi-IN', 'hu-HU', 'id-ID',
+    'it-IT', 'ja-JP', 'ka-GE', 'kk-KZ', 'kn-IN', 'ko-KR', 'lt-LT', 'lv-LV', 'ml-IN', 'ms-MY', 'ms-SG',
+    'nb-NO', 'nl-NL', 'no-NO', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'si-LK', 'sk-SK', 'sl-SI',
+    'sr-RS', 'sv-SE', 'ta-IN', 'te-IN', 'th-TH', 'tl-PH', 'tr-TR', 'uk-UA', 'vi-VN', 'zh-CN', 'zh-HK',
+    'zh-TW', 'zu-ZA']

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -411,10 +411,6 @@ msgctxt "#30734"
 msgid "Enable"
 msgstr ""
 
-msgctxt "#30735"
-msgid "https://torrentio.strem.fun/"
-msgstr ""
-
 msgctxt "#30736"
 msgid "Priority Language"
 msgstr ""
@@ -551,20 +547,12 @@ msgctxt "#30769"
 msgid "Elfhosted/KnightCrawler Configuration"
 msgstr ""
 
-msgctxt "#30770"
-msgid "https://torrentio.elfhosted.com/"
-msgstr ""
-
 msgctxt "#30771"
 msgid "Zilean Configuration"
 msgstr ""
 
 msgctxt "#30772"
 msgid "Zilean Host"
-msgstr ""
-
-msgctxt "#30773"
-msgid "https://zilean.elfhosted.com"
 msgstr ""
 
 msgctxt "#30774"
@@ -581,10 +569,6 @@ msgstr ""
 
 msgctxt "#30777"
 msgid "MediaFusion configuration"
-msgstr ""
-
-msgctxt "#30778"
-msgid "https://mediafusion.elfhosted.com"
 msgstr ""
 
 msgctxt "#30779"
@@ -667,24 +651,12 @@ msgctxt "#30798"
 msgid "Trakt Client"
 msgstr ""
 
-msgctxt "#30799"
-msgid "1038ef327e86e7f6d39d80d2eb5479bff66dd8394e813c5e0e387af0f84d89fb"
-msgstr ""
-
 msgctxt "#30800"
 msgid "Trakt Secret"
 msgstr ""
 
-msgctxt "#30801"
-msgid "8d27a92e1d17334dae4a0590083a4f26401cb8f721f477a79fd3f218f8534fd1"
-msgstr ""
-
 msgctxt "#30802"
 msgid "Log out"
-msgstr ""
-
-msgctxt "#30803"
-msgid "fa836e1c874ba95ab08a14ee88e05565"
 msgstr ""
 
 msgctxt "#30804"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -788,10 +788,10 @@ msgctxt "#40029"
 msgid "Hebrew (Israel)"
 msgstr ""
 
-msgctx "#42005"
+msgctxt "#42418"
 msgid "Language and country"
 msgstr ""
 
 msgctxt "#42419"
-msgid "The language and country settings used when looking up data from TMDb and Trakt APIs"
+msgid "The language and country settings used when looking up data from TMDb"
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -360,7 +360,7 @@ msgid "Cache Enabled"
 msgstr ""
 
 msgctxt "#30722"
-msgid "Cache Expiration (days)"
+msgid "Cache Expiration (hours)"
 msgstr ""
 
 msgctxt "#30723"
@@ -667,6 +667,9 @@ msgctxt "#30805"
 msgid "Show Telegram Menu"
 msgstr ""
 
+msgctxt "#30806"
+msgid "Clear cache when update"
+msgstr ""
 
 msgctxt "#40000"
 msgid "Arabic (United Arab Emirates)"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -314,3 +314,512 @@ msgstr ""
 msgctxt "#30710"
 msgid "Filter TV Shows by Season and Episode"
 msgstr ""
+
+msgctxt "#30711"
+msgid "Torrent Settings"
+msgstr ""
+
+msgctxt "#30712"
+msgid "General"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Use Torrent"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Jacktorr"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Torrest"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Elementum"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Auto-Play"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Enable Next Episode Dialog"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Seconds left before show Next Episode Dialog"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Cache Enabled"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Cache Expiration (days)"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Update"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Indexers Configuration"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Sort"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Seeds"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Size"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Cached"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Date"
+msgstr ""
+
+msgctxt "#30732"
+msgid "None"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Torrentio Configuration"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Enable"
+msgstr ""
+
+msgctxt "#30735"
+msgid "https://torrentio.strem.fun/"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Priority Language"
+msgstr ""
+
+msgctxt "#30737"
+msgid "GB"
+msgstr ""
+
+msgctxt "#30738"
+msgid "JP"
+msgstr ""
+
+msgctxt "#30739"
+msgid "RU"
+msgstr ""
+
+msgctxt "#30740"
+msgid "IT"
+msgstr ""
+
+msgctxt "#30741"
+msgid "PT"
+msgstr ""
+
+msgctxt "#30742"
+msgid "ES"
+msgstr ""
+
+msgctxt "#30743"
+msgid "MX"
+msgstr ""
+
+msgctxt "#30744"
+msgid "KR"
+msgstr ""
+
+msgctxt "#30745"
+msgid "CN"
+msgstr ""
+
+msgctxt "#30746"
+msgid "TW"
+msgstr ""
+
+msgctxt "#30747"
+msgid "FR"
+msgstr ""
+
+msgctxt "#30748"
+msgid "DE"
+msgstr ""
+
+msgctxt "#30749"
+msgid "NL"
+msgstr ""
+
+msgctxt "#30750"
+msgid "IN"
+msgstr ""
+
+msgctxt "#30751"
+msgid "PL"
+msgstr ""
+
+msgctxt "#30752"
+msgid "LT"
+msgstr ""
+
+msgctxt "#30753"
+msgid "CZ"
+msgstr ""
+
+msgctxt "#30754"
+msgid "SK"
+msgstr ""
+
+msgctxt "#30755"
+msgid "SI"
+msgstr ""
+
+msgctxt "#30756"
+msgid "HU"
+msgstr ""
+
+msgctxt "#30757"
+msgid "RO"
+msgstr ""
+
+msgctxt "#30758"
+msgid "HR"
+msgstr ""
+
+msgctxt "#30759"
+msgid "UA"
+msgstr ""
+
+msgctxt "#30760"
+msgid "GR"
+msgstr ""
+
+msgctxt "#30761"
+msgid "DK"
+msgstr ""
+
+msgctxt "#30762"
+msgid "FI"
+msgstr ""
+
+msgctxt "#30763"
+msgid "SE"
+msgstr ""
+
+msgctxt "#30764"
+msgid "NO"
+msgstr ""
+
+msgctxt "#30765"
+msgid "TR"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Torrentio Providers"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Jackgram Configuration"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Jackgram Host"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Elfhosted/KnightCrawler Configuration"
+msgstr ""
+
+msgctxt "#30770"
+msgid "https://torrentio.elfhosted.com/"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Zilean Configuration"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Zilean Host"
+msgstr ""
+
+msgctxt "#30773"
+msgid "https://zilean.elfhosted.com"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Zilean Timeout"
+msgstr ""
+
+msgctxt "#30775"
+msgid "Jackett Configuration"
+msgstr ""
+
+msgctxt "#30776"
+msgid "Prowlarr Configuration"
+msgstr ""
+
+msgctxt "#30777"
+msgid "MediaFusion configuration"
+msgstr ""
+
+msgctxt "#30778"
+msgid "https://mediafusion.elfhosted.com"
+msgstr ""
+
+msgctxt "#30779"
+msgid "Manifest Url"
+msgstr ""
+
+msgctxt "#30780"
+msgid "Jacktook Burst Configuration"
+msgstr ""
+
+msgctxt "#30781"
+msgid "Burst Configuration"
+msgstr ""
+
+msgctxt "#30782"
+msgid "User"
+msgstr ""
+
+msgctxt "#30783"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#30784"
+msgid "Remove Authorization"
+msgstr ""
+
+msgctxt "#30785"
+msgid "Premiumize Configuration"
+msgstr ""
+
+msgctxt "#30786"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30787"
+msgid "Token:"
+msgstr ""
+
+msgctxt "#30788"
+msgid "TorBox Configuration"
+msgstr ""
+
+msgctxt "#30789"
+msgid "EasyDebrid Configuration"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Uncached"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Show uncached torrents"
+msgstr ""
+
+msgctxt "#30792"
+msgid "Use Kodi Language"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Trakt"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Trakt Configuration"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Expires"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Refresh"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Token"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Trakt Client"
+msgstr ""
+
+msgctxt "#30799"
+msgid "1038ef327e86e7f6d39d80d2eb5479bff66dd8394e813c5e0e387af0f84d89fb"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Trakt Secret"
+msgstr ""
+
+msgctxt "#30801"
+msgid "8d27a92e1d17334dae4a0590083a4f26401cb8f721f477a79fd3f218f8534fd1"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Log out"
+msgstr ""
+
+msgctxt "#30803"
+msgid "fa836e1c874ba95ab08a14ee88e05565"
+msgstr ""
+
+msgctxt "#30804"
+msgid "Menus"
+msgstr ""
+
+msgctxt "#30805"
+msgid "Show Telegram Menu"
+msgstr ""
+
+
+msgctxt "#40000"
+msgid "Arabic (United Arab Emirates)"
+msgstr ""
+
+msgctxt "#40001"
+msgid "Arabic (Saudi Arabia)"
+msgstr ""
+
+msgctxt "#40002"
+msgid "Belarusian (Belarus)"
+msgstr ""
+
+msgctxt "#40003"
+msgid "Bulgarian (Bulgaria)"
+msgstr ""
+
+msgctxt "#40004"
+msgid "Bengali (Bangladesh)"
+msgstr ""
+
+msgctxt "#40005"
+msgid "Catalan (Spain)"
+msgstr ""
+
+msgctxt "#40006"
+msgid "Chamorro (Guam)"
+msgstr ""
+
+msgctxt "#40007"
+msgid "Czech (Czech Republic)"
+msgstr ""
+
+msgctxt "#40008"
+msgid "Danish (Denmark)"
+msgstr ""
+
+msgctxt "#40009"
+msgid "German (Austria)"
+msgstr ""
+
+msgctxt "#40010"
+msgid "German (Switzerland)"
+msgstr ""
+
+msgctxt "#40011"
+msgid "German (Germany)"
+msgstr ""
+
+msgctxt "#40012"
+msgid "Greek (Greece)"
+msgstr ""
+
+msgctxt "#40013"
+msgid "English (Australia)"
+msgstr ""
+
+msgctxt "#40014"
+msgid "English (Canada)"
+msgstr ""
+
+msgctxt "#40015"
+msgid "English (United Kingdom)"
+msgstr ""
+
+msgctxt "#40016"
+msgid "English (Ireland)"
+msgstr ""
+
+msgctxt "#40017"
+msgid "English (New Zealand)"
+msgstr ""
+
+msgctxt "#40018"
+msgid "English (United States of America)"
+msgstr ""
+
+msgctxt "#40019"
+msgid "Esperanto (None)"
+msgstr ""
+
+msgctxt "#40020"
+msgid "Spanish (Spain)"
+msgstr ""
+
+msgctxt "#40021"
+msgid "Spanish (Mexico)"
+msgstr ""
+
+msgctxt "#40022"
+msgid "Estonian (Estonia)"
+msgstr ""
+
+msgctxt "#40023"
+msgid "Basque (Spain)"
+msgstr ""
+
+msgctxt "#40024"
+msgid "Persian (Iran)"
+msgstr ""
+
+msgctxt "#40025"
+msgid "Finnish (Finland)"
+msgstr ""
+
+msgctxt "#40026"
+msgid "French (Canada)"
+msgstr ""
+
+msgctxt "#40027"
+msgid "French (France)"
+msgstr ""
+
+msgctxt "#40028"
+msgid "Galician (Spain)"
+msgstr ""
+
+msgctxt "#40029"
+msgid "Hebrew (Israel)"
+msgstr ""
+
+msgctx "#42005"
+msgid "Language and country"
+msgstr ""
+
+msgctxt "#42419"
+msgid "The language and country settings used when looking up data from TMDb and Trakt APIs"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -791,6 +791,158 @@ msgctxt "#40029"
 msgid "Hebrew (Israel)"
 msgstr ""
 
+msgctxt "#40030"
+msgid "Hindi (India)"
+msgstr ""
+
+msgctxt "#40031"
+msgid "Hungarian (Hungary)"
+msgstr ""
+
+msgctxt "#40032"
+msgid "Indonesian (Indonesia)"
+msgstr ""
+
+msgctxt "#40033"
+msgid "Italian (Italy)"
+msgstr ""
+
+msgctxt "#40034"
+msgid "Japanese (Japan)"
+msgstr ""
+
+msgctxt "#40035"
+msgid "Georgian (Georgia)"
+msgstr ""
+
+msgctxt "#40036"
+msgid "Kazakh (Kazakhstan)"
+msgstr ""
+
+msgctxt "#40037"
+msgid "Kannada (India)"
+msgstr ""
+
+msgctxt "#40038"
+msgid "Korean (South Korea)"
+msgstr ""
+
+msgctxt "#40039"
+msgid "Lithuanian (Lithuania)"
+msgstr ""
+
+msgctxt "#40040"
+msgid "Latvian (Latvia)"
+msgstr ""
+
+msgctxt "#40041"
+msgid "Malayalam (India)"
+msgstr ""
+
+msgctxt "#40042"
+msgid "Malay (Malaysia)"
+msgstr ""
+
+msgctxt "#40043"
+msgid "Malay (Singapore)"
+msgstr ""
+
+msgctxt "#40044"
+msgid "Norwegian Bokmål (Norway)"
+msgstr ""
+
+msgctxt "#40045"
+msgid "Dutch (Netherlands)"
+msgstr ""
+
+msgctxt "#40046"
+msgid "Norwegian (Norway)"
+msgstr ""
+
+msgctxt "#40047"
+msgid "Polish (Poland)"
+msgstr ""
+
+msgctxt "#40048"
+msgid "Portuguese (Brazil)"
+msgstr ""
+
+msgctxt "#40049"
+msgid "Portuguese (Portugal)"
+msgstr ""
+
+msgctxt "#40050"
+msgid "Romanian (Romania)"
+msgstr ""
+
+msgctxt "#40051"
+msgid "Russian (Russia)"
+msgstr ""
+
+msgctxt "#40052"
+msgid "Sinhalese (Sri Lanka)"
+msgstr ""
+
+msgctxt "#40053"
+msgid "Slovak (Slovakia)"
+msgstr ""
+
+msgctxt "#40054"
+msgid "Slovenian (Slovenia)"
+msgstr ""
+
+msgctxt "#40055"
+msgid "Serbian (Serbia)"
+msgstr ""
+
+msgctxt "#40056"
+msgid "Swedish (Sweden)"
+msgstr ""
+
+msgctxt "#40057"
+msgid "Tamil (India)"
+msgstr ""
+
+msgctxt "#40058"
+msgid "Telugu (India)"
+msgstr ""
+
+msgctxt "#40059"
+msgid "Thai (Thailand)"
+msgstr ""
+
+msgctxt "#40060"
+msgid "Tagalog (Philippines)"
+msgstr ""
+
+msgctxt "#40061"
+msgid "Turkish (Turkey)"
+msgstr ""
+
+msgctxt "#40062"
+msgid "Ukrainian (Ukraine)"
+msgstr ""
+
+msgctxt "#40063"
+msgid "Vietnamese (Vietnam)"
+msgstr ""
+
+msgctxt "#40064"
+msgid "Mandarin (China)"
+msgstr ""
+
+msgctxt "#40065"
+msgid "Mandarin (Hong Kong)"
+msgstr ""
+
+msgctxt "#40066"
+msgid "Mandarin (Taiwan)"
+msgstr ""
+
+msgctxt "#40067"
+msgid "Zulu (South Africa)"
+msgstr ""
+
 msgctxt "#42418"
 msgid "Language and country"
 msgstr ""

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -656,8 +656,8 @@ msgid "Show Telegram Menu"
 msgstr "Mostrar menú de Telegram"
 
 msgctxt "#30806"
-msgid "Limpiar cache al actualizar"
-msgstr ""
+msgid "Clear cache when update"
+msgstr "Limpiar cache al actualizar"
 
 msgctxt "#40000"
 msgid "Arabic (United Arab Emirates)"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -779,6 +779,158 @@ msgctxt "#40029"
 msgid "Hebrew (Israel)"
 msgstr "Hebreo (Israel)"
 
+msgctxt "#40030"
+msgid "Hindi (India)"
+msgstr "Hindi (India)"
+
+msgctxt "#40031"
+msgid "Hungarian (Hungary)"
+msgstr "Húngaro (Hungría)"
+
+msgctxt "#40032"
+msgid "Indonesian (Indonesia)"
+msgstr "Indonesio (Indonesia)"
+
+msgctxt "#40033"
+msgid "Italian (Italy)"
+msgstr "Italiano (Italia)"
+
+msgctxt "#40034"
+msgid "Japanese (Japan)"
+msgstr "Japonés (Japón)"
+
+msgctxt "#40035"
+msgid "Georgian (Georgia)"
+msgstr "Georgiano (Georgia)"
+
+msgctxt "#40036"
+msgid "Kazakh (Kazakhstan)"
+msgstr "Kazajo (Kazajistán)"
+
+msgctxt "#40037"
+msgid "Kannada (India)"
+msgstr "Kannada (India)"
+
+msgctxt "#40038"
+msgid "Korean (South Korea)"
+msgstr "Coreano (Corea del Sur)"
+
+msgctxt "#40039"
+msgid "Lithuanian (Lithuania)"
+msgstr "Lituano (Lituania)"
+
+msgctxt "#40040"
+msgid "Latvian (Latvia)"
+msgstr "Letón (Letonia)"
+
+msgctxt "#40041"
+msgid "Malayalam (India)"
+msgstr "Malayalam (India)"
+
+msgctxt "#40042"
+msgid "Malay (Malaysia)"
+msgstr "Malayo (Malasia)"
+
+msgctxt "#40043"
+msgid "Malay (Singapore)"
+msgstr "Malayo (Singapur)"
+
+msgctxt "#40044"
+msgid "Norwegian Bokmål (Norway)"
+msgstr "Bokmål noruego (Noruega)"
+
+msgctxt "#40045"
+msgid "Dutch (Netherlands)"
+msgstr "Holandés (Países Bajos)"
+
+msgctxt "#40046"
+msgid "Norwegian (Norway)"
+msgstr "Noruego (Noruega)"
+
+msgctxt "#40047"
+msgid "Polish (Poland)"
+msgstr "Polaco (Polonia)"
+
+msgctxt "#40048"
+msgid "Portuguese (Brazil)"
+msgstr "Portugués (Brasil)"
+
+msgctxt "#40049"
+msgid "Portuguese (Portugal)"
+msgstr "Portugués (portugal)"
+
+msgctxt "#40050"
+msgid "Romanian (Romania)"
+msgstr "Rumano (Rumania)"
+
+msgctxt "#40051"
+msgid "Russian (Russia)"
+msgstr "Ruso (Rusia)"
+
+msgctxt "#40052"
+msgid "Sinhalese (Sri Lanka)"
+msgstr "Cingales (Sri Lanka)"
+
+msgctxt "#40053"
+msgid "Slovak (Slovakia)"
+msgstr "Eslovaco (Eslovaquia)"
+
+msgctxt "#40054"
+msgid "Slovenian (Slovenia)"
+msgstr "Esloveno (Eslovenia)"
+
+msgctxt "#40055"
+msgid "Serbian (Serbia)"
+msgstr "Serbio (Serbia)"
+
+msgctxt "#40056"
+msgid "Swedish (Sweden)"
+msgstr "Sueco (Suecia)"
+
+msgctxt "#40057"
+msgid "Tamil (India)"
+msgstr "Tamil (India)"
+
+msgctxt "#40058"
+msgid "Telugu (India)"
+msgstr "Telugu (India)"
+
+msgctxt "#40059"
+msgid "Thai (Thailand)"
+msgstr "Tailandés (Tailandia)"
+
+msgctxt "#40060"
+msgid "Tagalog (Philippines)"
+msgstr "Tagalo (Philippines)"
+
+msgctxt "#40061"
+msgid "Turkish (Turkey)"
+msgstr "Turco (Turquía"
+
+msgctxt "#40062"
+msgid "Ukrainian (Ukraine)"
+msgstr "Ucraniano (Ucrania)"
+
+msgctxt "#40063"
+msgid "Vietnamese (Vietnam)"
+msgstr "Vietnamita (Vietnam)"
+
+msgctxt "#40064"
+msgid "Mandarin (China)"
+msgstr "Mandarin (China)"
+
+msgctxt "#40065"
+msgid "Mandarin (Hong Kong)"
+msgstr "Mandarin (Hong Kong)"
+
+msgctxt "#40066"
+msgid "Mandarin (Taiwan)"
+msgstr "Mandarin (Taiwan)"
+
+msgctxt "#40067"
+msgid "Zulu (South Africa)"
+msgstr "Zulú (Sudáfrica)"
+
 msgctxt "#42418"
 msgid "Language and country"
 msgstr "Idioma y país"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -302,3 +302,511 @@ msgstr "Drop torrent"
 msgctxt "#30710"
 msgid "Filter TV Shows by Season and Episode"
 msgstr "Filtrar programas de TV por temporada y episodio"
+
+msgctxt "#30711"
+msgid "Torrent Settings"
+msgstr "Configuración de Torrents"
+
+msgctxt "#30712"
+msgid "General"
+msgstr "General"
+
+msgctxt "#30713"
+msgid "Use Torrent"
+msgstr "Usar Torrent"
+
+msgctxt "#30714"
+msgid "Jacktorr"
+msgstr "Jacktorr"
+
+msgctxt "#30715"
+msgid "Torrest"
+msgstr "Torrest"
+
+msgctxt "#30716"
+msgid "Elementum"
+msgstr "Elementum"
+
+msgctxt "#30717"
+msgid "Playback"
+msgstr "Reproducción"
+
+msgctxt "#30718"
+msgid "Auto-Play"
+msgstr "Reproducción automática"
+
+msgctxt "#30719"
+msgid "Enable Next Episode Dialog"
+msgstr "Próximo episodio"
+
+msgctxt "#30720"
+msgid "Seconds left before show Next Episode Dialog"
+msgstr "Segundos para siguiente episodio"
+
+msgctxt "#30721"
+msgid "Cache Enabled"
+msgstr "Caché habilitada"
+
+msgctxt "#30722"
+msgid "Cache Expiration (days)"
+msgstr "Expiración de caché (días)"
+
+msgctxt "#30723"
+msgid "Cache"
+msgstr "Caché"
+
+msgctxt "#30724"
+msgid "Update"
+msgstr "Actualizar"
+
+msgctxt "#30725"
+msgid "Indexers Configuration"
+msgstr "Configuración de indexadores"
+
+msgctxt "#30726"
+msgid "Sort"
+msgstr "Ordenar"
+
+msgctxt "#30727"
+msgid "Quality"
+msgstr "Calidad"
+
+msgctxt "#30728"
+msgid "Seeds"
+msgstr "Seeds"
+
+msgctxt "#30729"
+msgid "Size"
+msgstr "Tamaño"
+
+msgctxt "#30730"
+msgid "Cached"
+msgstr "En caché"
+
+msgctxt "#30731"
+msgid "Date"
+msgstr "Fecha"
+
+msgctxt "#30732"
+msgid "None"
+msgstr "Ninguno"
+
+msgctxt "#30733"
+msgid "Torrentio Configuration"
+msgstr "Configuración de Torrentio"
+
+msgctxt "#30734"
+msgid "Enable"
+msgstr "Habilitar"
+
+msgctxt "#30735"
+msgid "https://torrentio.strem.fun/"
+msgstr "https://torrentio.strem.fun/"
+
+msgctxt "#30736"
+msgid "Priority Language"
+msgstr "Idioma prioritario"
+
+msgctxt "#30737"
+msgid "GB"
+msgstr "GB"
+
+msgctxt "#30738"
+msgid "JP"
+msgstr "JP"
+
+msgctxt "#30739"
+msgid "RU"
+msgstr "RU"
+
+msgctxt "#30740"
+msgid "IT"
+msgstr "IT"
+
+msgctxt "#30741"
+msgid "PT"
+msgstr "PT"
+
+msgctxt "#30742"
+msgid "ES"
+msgstr "ES"
+
+msgctxt "#30743"
+msgid "MX"
+msgstr "MX"
+
+msgctxt "#30744"
+msgid "KR"
+msgstr "KR"
+
+msgctxt "#30745"
+msgid "CN"
+msgstr "CN"
+
+msgctxt "#30746"
+msgid "TW"
+msgstr "TW"
+
+msgctxt "#30747"
+msgid "FR"
+msgstr "FR"
+
+msgctxt "#30748"
+msgid "DE"
+msgstr "DE"
+
+msgctxt "#30749"
+msgid "NL"
+msgstr "NL"
+
+msgctxt "#30750"
+msgid "IN"
+msgstr "IN"
+
+msgctxt "#30751"
+msgid "PL"
+msgstr "PL"
+
+msgctxt "#30752"
+msgid "LT"
+msgstr "LT"
+
+msgctxt "#30753"
+msgid "CZ"
+msgstr "CZ"
+
+msgctxt "#30754"
+msgid "SK"
+msgstr "SK"
+
+msgctxt "#30755"
+msgid "SI"
+msgstr "SI"
+
+msgctxt "#30756"
+msgid "HU"
+msgstr "HU"
+
+msgctxt "#30757"
+msgid "RO"
+msgstr "RO"
+
+msgctxt "#30758"
+msgid "HR"
+msgstr "HR"
+
+msgctxt "#30759"
+msgid "UA"
+msgstr "UA"
+
+msgctxt "#30760"
+msgid "GR"
+msgstr "GR"
+
+msgctxt "#30761"
+msgid "DK"
+msgstr "DK"
+
+msgctxt "#30762"
+msgid "FI"
+msgstr "FI"
+
+msgctxt "#30763"
+msgid "SE"
+msgstr "SE"
+
+msgctxt "#30764"
+msgid "NO"
+msgstr "NO"
+
+msgctxt "#30765"
+msgid "TR"
+msgstr "TR"
+
+msgctxt "#30766"
+msgid "Torrentio Providers"
+msgstr "Proveedores de Torrentio"
+
+msgctxt "#30767"
+msgid "Jackgram Configuration"
+msgstr "Configuración de Jackgram"
+
+msgctxt "#30768"
+msgid "Jackgram Host"
+msgstr "Host de Jackgram"
+
+msgctxt "#30769"
+msgid "Elfhosted/KnightCrawler Configuration"
+msgstr "Configuración de Elfhosted/KnightCrawler"
+
+msgctxt "#30770"
+msgid "https://torrentio.elfhosted.com/"
+msgstr "https://torrentio.elfhosted.com/"
+
+msgctxt "#30771"
+msgid "Zilean Configuration"
+msgstr "Configuración de Zilean"
+
+msgctxt "#30772"
+msgid "Zilean Host"
+msgstr "Host de Zilean"
+
+msgctxt "#30773"
+msgid "https://zilean.elfhosted.com"
+msgstr "https://zilean.elfhosted.com"
+
+msgctxt "#30774"
+msgid "Zilean Timeout"
+msgstr "Tiempo de espera de Zilean"
+
+msgctxt "#30775"
+msgid "Jackett Configuration"
+msgstr "Configuración de Jackett"
+
+msgctxt "#30776"
+msgid "Prowlarr Configuration"
+msgstr "Configuración de Prowlarr"
+
+msgctxt "#30777"
+msgid "MediaFusion configuration"
+msgstr "Configuración de MediaFusion"
+
+msgctxt "#30778"
+msgid "https://mediafusion.elfhosted.com"
+msgstr "https://mediafusion.elfhosted.com"
+
+msgctxt "#30779"
+msgid "Manifest Url"
+msgstr "URL del manifiesto"
+
+msgctxt "#30780"
+msgid "Jacktook Burst Configuration"
+msgstr "Configuración de Jacktook Burst"
+
+msgctxt "#30781"
+msgid "Burst Configuration"
+msgstr "Configuración de Burst"
+
+msgctxt "#30782"
+msgid "User"
+msgstr "Usuario"
+
+msgctxt "#30783"
+msgid "Authorize"
+msgstr "Autorizar"
+
+msgctxt "#30784"
+msgid "Remove Authorization"
+msgstr "Eliminar autorización"
+
+msgctxt "#30785"
+msgid "Premiumize Configuration"
+msgstr "Configuración de Premiumize"
+
+msgctxt "#30786"
+msgid "Enabled"
+msgstr "Habilitado"
+
+msgctxt "#30787"
+msgid "Token:"
+msgstr "Token:"
+
+msgctxt "#30788"
+msgid "TorBox Configuration"
+msgstr "Configuración de TorBox"
+
+msgctxt "#30789"
+msgid "EasyDebrid Configuration"
+msgstr "Configuración de EasyDebrid"
+
+msgctxt "#30790"
+msgid "Uncached"
+msgstr "Uncached"
+
+msgctxt "#30791"
+msgid "Show uncached torrents"
+msgstr "Mostrar torrents sin caché"
+
+msgctxt "#30792"
+msgid "Use Kodi Language"
+msgstr "Usar idioma de Kodi"
+
+msgctxt "#30793"
+msgid "Trakt"
+msgstr "Trakt"
+
+msgctxt "#30794"
+msgid "Trakt Configuration"
+msgstr "Configuración de Trakt"
+
+msgctxt "#30795"
+msgid "Expires"
+msgstr "Expira"
+
+msgctxt "#30796"
+msgid "Refresh"
+msgstr "Actualizar"
+
+msgctxt "#30797"
+msgid "Token"
+msgstr "Token"
+
+msgctxt "#30798"
+msgid "Trakt Client"
+msgstr "Cliente de Trakt"
+
+msgctxt "#30799"
+msgid "1038ef327e86e7f6d39d80d2eb5479bff66dd8394e813c5e0e387af0f84d89fb"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Trakt Secret"
+msgstr "Secreto de Trakt"
+
+msgctxt "#30801"
+msgid "8d27a92e1d17334dae4a0590083a4f26401cb8f721f477a79fd3f218f8534fd1"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Log out"
+msgstr "Cerrar sesión"
+
+msgctxt "#30803"
+msgid "fa836e1c874ba95ab08a14ee88e05565"
+msgstr "fa836e1c874ba95ab08a14ee88e05565"
+
+msgctxt "#30804"
+msgid "Menus"
+msgstr "Menús"
+
+msgctxt "#30805"
+msgid "Show Telegram Menu"
+msgstr "Mostrar menú de Telegram"
+
+msgctxt "#40000"
+msgid "Arabic (United Arab Emirates)"
+msgstr "Árabe (Emiratos Árabes Unidos)"
+
+msgctxt "#40001"
+msgid "Arabic (Saudi Arabia)"
+msgstr "Árabe (Arabia Saudita)"
+
+msgctxt "#40002"
+msgid "Belarusian (Belarus)"
+msgstr "Bielorruso (Bielorrusia)"
+
+msgctxt "#40003"
+msgid "Bulgarian (Bulgaria)"
+msgstr "Búlgaro (Bulgaria)"
+
+msgctxt "#40004"
+msgid "Bengali (Bangladesh)"
+msgstr "Bengalí (Bangladesh)"
+
+msgctxt "#40005"
+msgid "Catalan (Spain)"
+msgstr "Catalán (España)"
+
+msgctxt "#40006"
+msgid "Chamorro (Guam)"
+msgstr "Chamorro (Guam)"
+
+msgctxt "#40007"
+msgid "Czech (Czech Republic)"
+msgstr "Checo (República Checa)"
+
+msgctxt "#40008"
+msgid "Danish (Denmark)"
+msgstr "Danés (Dinamarca)"
+
+msgctxt "#40009"
+msgid "German (Austria)"
+msgstr "Alemán (Austria)"
+
+msgctxt "#40010"
+msgid "German (Switzerland)"
+msgstr "Alemán (Suiza)"
+
+msgctxt "#40011"
+msgid "German (Germany)"
+msgstr "Alemán (Alemania)"
+
+msgctxt "#40012"
+msgid "Greek (Greece)"
+msgstr "Griego (Grecia)"
+
+msgctxt "#40013"
+msgid "English (Australia)"
+msgstr "Inglés (Australia)"
+
+msgctxt "#40014"
+msgid "English (Canada)"
+msgstr "Inglés (Canadá)"
+
+msgctxt "#40015"
+msgid "English (United Kingdom)"
+msgstr "Inglés (Reino Unido)"
+
+msgctxt "#40016"
+msgid "English (Ireland)"
+msgstr "Inglés (Irlanda)"
+
+msgctxt "#40017"
+msgid "English (New Zealand)"
+msgstr "Inglés (Nueva Zelanda)"
+
+msgctxt "#40018"
+msgid "English (United States of America)"
+msgstr "Inglés (Estados Unidos de América)"
+
+msgctxt "#40019"
+msgid "Esperanto (None)"
+msgstr "Esperanto (Ninguno)"
+
+msgctxt "#40020"
+msgid "Spanish (Spain)"
+msgstr "Español (España)"
+
+msgctxt "#40021"
+msgid "Spanish (Mexico)"
+msgstr "Español (México)"
+
+msgctxt "#40022"
+msgid "Estonian (Estonia)"
+msgstr "Estonio (Estonia)"
+
+msgctxt "#40023"
+msgid "Basque (Spain)"
+msgstr "Vasco (España)"
+
+msgctxt "#40024"
+msgid "Persian (Iran)"
+msgstr "Persa (Irán)"
+
+msgctxt "#40025"
+msgid "Finnish (Finland)"
+msgstr "Finlandés (Finlandia)"
+
+msgctxt "#40026"
+msgid "French (Canada)"
+msgstr "Francés (Canadá)"
+
+msgctxt "#40027"
+msgid "French (France)"
+msgstr "Francés (Francia)"
+
+msgctxt "#40028"
+msgid "Galician (Spain)"
+msgstr "Gallego (España)"
+
+msgctxt "#40029"
+msgid "Hebrew (Israel)"
+msgstr "Hebreo (Israel)"
+
+msgctx "#42005"
+msgid "Language and country"
+msgstr "Idioma y país"
+
+msgctxt "#42419"
+msgid "The language and country settings used when looking up data from TMDb and Trakt APIs"
+msgstr "La configuración de idioma y país utilizada al buscar datos de las API de TMDb y Trakt"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -277,11 +277,11 @@ msgstr "Pausar"
 
 msgctxt "#30705"
 msgid "Remove torrent"
-msgstr "Remover torrent"
+msgstr "Borrar torrent"
 
 msgctxt "#30706"
 msgid "Remove torrent and files"
-msgstr "Remover torrents y archivos"
+msgstr "Borrar torrents y archivos"
 
 msgctxt "#30707"
 msgid "Torrent status"
@@ -293,7 +293,7 @@ msgstr "Detener"
 
 msgctxt "#30800"
 msgid "Choose Torrent Client"
-msgstr ""
+msgstr "Cliente Torrent"
 
 msgctxt "#30709"
 msgid "Drop torrent"
@@ -398,10 +398,6 @@ msgstr "Configuración de Torrentio"
 msgctxt "#30734"
 msgid "Enable"
 msgstr "Habilitar"
-
-msgctxt "#30735"
-msgid "https://torrentio.strem.fun/"
-msgstr "https://torrentio.strem.fun/"
 
 msgctxt "#30736"
 msgid "Priority Language"
@@ -539,10 +535,6 @@ msgctxt "#30769"
 msgid "Elfhosted/KnightCrawler Configuration"
 msgstr "Configuración de Elfhosted/KnightCrawler"
 
-msgctxt "#30770"
-msgid "https://torrentio.elfhosted.com/"
-msgstr "https://torrentio.elfhosted.com/"
-
 msgctxt "#30771"
 msgid "Zilean Configuration"
 msgstr "Configuración de Zilean"
@@ -550,10 +542,6 @@ msgstr "Configuración de Zilean"
 msgctxt "#30772"
 msgid "Zilean Host"
 msgstr "Host de Zilean"
-
-msgctxt "#30773"
-msgid "https://zilean.elfhosted.com"
-msgstr "https://zilean.elfhosted.com"
 
 msgctxt "#30774"
 msgid "Zilean Timeout"
@@ -570,10 +558,6 @@ msgstr "Configuración de Prowlarr"
 msgctxt "#30777"
 msgid "MediaFusion configuration"
 msgstr "Configuración de MediaFusion"
-
-msgctxt "#30778"
-msgid "https://mediafusion.elfhosted.com"
-msgstr "https://mediafusion.elfhosted.com"
 
 msgctxt "#30779"
 msgid "Manifest Url"
@@ -605,7 +589,7 @@ msgstr "Configuración de Premiumize"
 
 msgctxt "#30786"
 msgid "Enabled"
-msgstr "Habilitado"
+msgstr "Habilitar"
 
 msgctxt "#30787"
 msgid "Token:"
@@ -655,25 +639,13 @@ msgctxt "#30798"
 msgid "Trakt Client"
 msgstr "Cliente de Trakt"
 
-msgctxt "#30799"
-msgid "1038ef327e86e7f6d39d80d2eb5479bff66dd8394e813c5e0e387af0f84d89fb"
-msgstr ""
-
 msgctxt "#30800"
 msgid "Trakt Secret"
 msgstr "Secreto de Trakt"
 
-msgctxt "#30801"
-msgid "8d27a92e1d17334dae4a0590083a4f26401cb8f721f477a79fd3f218f8534fd1"
-msgstr ""
-
 msgctxt "#30802"
 msgid "Log out"
 msgstr "Cerrar sesión"
-
-msgctxt "#30803"
-msgid "fa836e1c874ba95ab08a14ee88e05565"
-msgstr "fa836e1c874ba95ab08a14ee88e05565"
 
 msgctxt "#30804"
 msgid "Menus"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -348,8 +348,8 @@ msgid "Cache Enabled"
 msgstr "Caché habilitada"
 
 msgctxt "#30722"
-msgid "Cache Expiration (days)"
-msgstr "Expiración de caché (días)"
+msgid "Cache Expiration (hours)"
+msgstr "Expiración de caché (horas)"
 
 msgctxt "#30723"
 msgid "Cache"
@@ -654,6 +654,10 @@ msgstr "Menús"
 msgctxt "#30805"
 msgid "Show Telegram Menu"
 msgstr "Mostrar menú de Telegram"
+
+msgctxt "#30806"
+msgid "Limpiar cache al actualizar"
+msgstr ""
 
 msgctxt "#40000"
 msgid "Arabic (United Arab Emirates)"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -775,10 +775,10 @@ msgctxt "#40029"
 msgid "Hebrew (Israel)"
 msgstr "Hebreo (Israel)"
 
-msgctx "#42005"
+msgctxt "#42418"
 msgid "Language and country"
 msgstr "Idioma y país"
 
 msgctxt "#42419"
-msgid "The language and country settings used when looking up data from TMDb and Trakt APIs"
-msgstr "La configuración de idioma y país utilizada al buscar datos de las API de TMDb y Trakt"
+msgid "The language and country settings used when looking up data from TMDb"
+msgstr "La configuración de idioma y país utilizada al buscar datos de TMDb"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -206,7 +206,10 @@
                     <control type="toggle" />
                 </setting>
                 <setting id="jackgram_host" type="string" label="30768" help="">
-                    <default />
+                    <default/>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -222,6 +225,9 @@
                 </setting>
                 <setting id="elfhosted_host" type="string" label="30025" help="">
                     <default>https://torrentio.elfhosted.com/</default>
+                    <constraints>
+                        <allowempty>false</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -237,6 +243,9 @@
                 </setting>
                 <setting id="zilean_host" type="string" label="30772" help="">
                     <default>https://zilean.elfhosted.com</default>
+                    <constraints>
+                        <allowempty>false</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -267,7 +276,10 @@
                     <control type="toggle" />
                 </setting>
                 <setting id="jackett_host" type="string" label="30025" help="">
-                    <default />
+                    <default/>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -276,7 +288,10 @@
                     </dependencies>
                 </setting>
                 <setting id="jackett_apikey" type="string" label="30023" help="">
-                    <default />
+                    <default/>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -308,7 +323,10 @@
                 </setting>
                 <setting id="prowlarr_host" type="string" label="30052" help="">
                     <default />
-                    <control type="edit" format="string" />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string"/>
                     <dependencies>
                         <dependency type="visible">
                             <condition operator="is" setting="prowlarr_enabled">true</condition>
@@ -317,6 +335,9 @@
                 </setting>
                 <setting id="prowlarr_apikey" type="string" label="30051" help="">
                     <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -326,6 +347,9 @@
                 </setting>
                 <setting id="prowlarr_indexer_ids" type="string" label="30053" help="">
                     <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -366,6 +390,9 @@
                 </setting>
                 <setting id="mediafusion_manifest_url" type="string" label="30779" help="">
                     <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -410,6 +437,9 @@
                 </setting>
                 <setting id="real_debrid_user" type="string" label="30782" help="">
                     <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -484,6 +514,9 @@
                 </setting>
                 <setting id="torbox_token" type="string" label="30787" help="">
                     <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -499,6 +532,9 @@
                 </setting>
                 <setting id="easydebrid_token" type="string" label="30787" help="">
                     <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -518,6 +554,9 @@
             <group id="tmdb" label="30102">
                 <setting id="tmdb_apikey" type="string" label="30103" help="">
                     <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
                     <control type="edit" format="string" />
                 </setting>
                 <setting id="language" type="integer" label="42418" help="42419">

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,104 +1,583 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-    <category label="30001">
-        <setting id="torrent_enable" type="bool" label="Use Torrent" default="true"/>
-        <setting id="torrent_client" type="labelenum" label="30002" values="Jacktorr|Torrest|Elementum" default="Jacktorr" visible="eq(-1,true)"/>
-        <setting label="Playback" type="lsep"/>
-        <setting id="auto_play" type="bool" label="Auto-Play" default="false"/>
-        <setting id="playnext_dialog_enabled" type="bool" label="Enable Next Episode Dialog" default="true"/>
-        <setting id="playnext_time" type="slider" label="Seconds left before show Next Episode Dialog" option="int" range="10,5,180" default="50"/>
-        <setting label="Cache" type="lsep"/>
-        <setting id="cache_enabled" type="bool" label="30107" default="true"/>
-        <setting id="cache_expiration" type="slider" label="30105" option="int" range="1,1,30" default="24"/>
-        <setting type="action" label="30106" action="RunPlugin(plugin://plugin.video.jacktook/?action=clear_all_cached)" />
-        <setting label="Update" type="lsep"/>
-        <setting type="action" label="Update addon" action="RunPlugin(plugin://plugin.video.jacktook/?action=addon_update)"/>
-        <setting id="clear_cache_update" type="bool" label="Clear cache when update" default="true"/>
-    </category>
-    <category label="30020">
-        <setting label="Indexers Configuration" type="lsep"/>
-        <setting id="indexers_total_results" type="number" label="30029" default="60"/>
-        <setting id="indexers_desc_length" type="number" label="30026" default="100"/>
-        <setting id="indexers_sort_by" type="labelenum" label="Sort" values="Seeds|Size|Quality|Cached|Date|None" default="Quality"/>
-        <setting id="filter_by_episode" type="bool" label="30710" default="true"/>
-        <setting label="Torrentio Configuration" type="lsep"/>
-        <setting id="torrentio_enabled" type="bool" label="Enable" default="true"/>
-        <setting id="torrentio_host" type="text" label="30025" default="https://torrentio.strem.fun/" visible="eq(-1,true)"/>
-        <setting id="torrentio_priority_lang" type="labelenum" label="Priority Language" values="GB|JP|RU|IT|PT|ES|MX|KR|CN|TW|FR|DE|NL|IN|PL|LT|CZ|SK|SI|HU|RO|HR|UA|GR|DK|FI|SE|NO|TR|None" default="None" visible="eq(-2,true)"/>
-        <setting type="text" label="Click below to select torrentio providers" enable="false" visible="eq(-3,true)"  /> 
-        <setting type="action" label="Torrentio Providers" action="RunPlugin(plugin://plugin.video.jacktook/?action=torrentio_selection)" visible="eq(-4,true)"/>
-        <setting label="Jackgram Configuration" type="lsep"/>
-        <setting id="jackgram_enabled" type="bool" label="Enable" default="false"/>
-        <setting id="jackgram_host" type="text" label="Jackgram Host" default="" visible="eq(-1,true)"/>
-        <setting label="Elfhosted/KnightCrawler Configuration" type="lsep"/>
-        <setting id="elfhosted_enabled" type="bool" label="Enable" default="true"/>
-        <setting id="elfhosted_host" type="text" label="30025" default="https://torrentio.elfhosted.com/" visible="eq(-1,true)"/>
-        <setting label="Zilean Configuration" type="lsep"/>
-        <setting id="zilean_enabled" type="bool" label="Enable" default="false"/>
-        <setting id="zilean_host" type="text" label="Zilean Host" default="https://zilean.elfhosted.com" visible="eq(-1,true)"/>
-        <setting id="zilean_timeout" type="number" label="Zilean Timeout" default="10"/>
-        <setting label="30022" type="lsep"/>
-        <setting id="jackett_enabled" type="bool" label="Enable" default="false"/>
-        <setting id="jackett_host" type="text" label="30025" default="" visible="eq(-1,true)"/>
-        <setting id="jackett_apikey" type="text" label="30023" default="" visible="eq(-2,true)"/>
-        <setting id="jackett_timeout" type="slider" label="30030" option="int" range="1,1,30" default="25" visible="eq(-3,true)"/>
-        <setting label="30050" type="lsep"/>
-        <setting id="prowlarr_enabled" type="bool" label="Enable" default="false"/>
-        <setting id="prowlarr_host" type="text" label="30052" default="" visible="eq(-1,true)"/>
-        <setting id="prowlarr_apikey" type="text" label="30051" default="" visible="eq(-2,true)"/>
-        <setting id="prowlarr_indexer_ids" type="text" label="30053" default="" visible="eq(-3,true)"/>
-        <setting id="prowlarr_timeout" type="slider" label="30031" option="int" range="1,1,30" default="25" visible="eq(-4,true)"/>
-        <setting label="MediaFusion configuration" type="lsep"/>
-        <setting id="mediafusion_enabled" type="bool" label="Enable" default="false"/>
-        <setting id="mediafusion_host" type="text" label="30052" default="https://mediafusion.elfhosted.com" visible="eq(-1,true)"/>
-        <setting id="mediafusion_manifest_url" type="text" label="Manifest Url" default="" visible="eq(-2,true)"/>
-        <setting label="Jacktook Burst Configuration" type="lsep"/>
-        <setting id="jacktookburst_enabled" type="bool" label="Enable" default="false"/>
-        <setting type="action" label="Burst Configuration" action="RunPlugin(plugin://plugin.video.jacktook/?action=open_burst_config)" visible="eq(-1,true)"/>
-    </category>
-    <category label="30150">
-        <setting label="30152" type="lsep"/>
-        <setting id="real_debrid_enabled" type="bool" label="Enable" default="false"/>
-        <setting id="real_debid_authorized" type="bool" label="" default="false" visible="false"/>
-        <setting id="real_debrid_user" type="text" label="User" default="" visible="eq(-1,true)"/>
-        <setting id="real_debrid_token" type="text" label="30154" default="" visible="false"/>
-        <setting type="action" label="Authorize" action="RunPlugin(plugin://plugin.video.jacktook/?action=rd_auth)" />
-        <setting type="action" label="Remove Authorization" action="RunPlugin(plugin://plugin.video.jacktook/?action=rd_remove_auth)" />
-        <setting label="Premiumize Configuration" type="lsep"/>
-        <setting id="premiumize_enabled" type="bool" label="Enabled" default="false"/>
-        <setting id="premiumize_token" type="text" label="Token:" default="" visible="false"/>
-        <setting type="action" label="Authorize" action="RunPlugin(plugin://plugin.video.jacktook/?action=pm_auth)" />
-        <setting label="TorBox Configuration" type="lsep"/>
-        <setting id="torbox_enabled" type="bool" label="Enabled" default="false"/>
-        <setting id="torbox_token" type="text" label="Token:" default=""/>
-        <setting label="EasyDebrid Configuration" type="lsep"/>
-        <setting id="easydebrid_enabled" type="bool" label="Enabled" default="false"/>
-        <setting id="easydebrid_token" type="text" label="Token:" default=""/>
-        <setting label="" type="lsep"/>
-        <setting id="show_uncached" type="bool" label="Show uncached torrents" default="true"/>
-    </category>
-    <category label="30100">
-        <setting label="30102" type="lsep"/>
-        <setting id="tmdb_apikey" type="text" label="30103" default=""/>
-        <setting id="kodi_language" type="bool" label="Use Kodi Language" default="false"/>
-    </category>
-    <category label="Trakt">
-        <setting label="Trakt Configuration" type="lsep"/>
-        <setting type="action" label="Authorize" action="RunPlugin(plugin://plugin.video.jacktook/?action=trakt_auth)" />
-        <setting id="trakt.expires" type="text" default="0" visible="false"/>
-        <setting id="trakt.refresh" type="text" default="0" visible="false"/>
-        <setting id="trakt.token" type="text" default="0" visible="false"/>
-        <setting id="trakt.user" type="text" default="0" visible="false"/>
-        <setting id="jacktook.trakt.client" type="text" label="Trakt Client" default="1038ef327e86e7f6d39d80d2eb5479bff66dd8394e813c5e0e387af0f84d89fb"/>
-        <setting id="jacktook.trakt.secret" type="text" label="Trakt Secret" default="8d27a92e1d17334dae4a0590083a4f26401cb8f721f477a79fd3f218f8534fd1"/>
-        <setting type="action" label="Log out" action="RunPlugin(plugin://plugin.video.jacktook/?action=trakt_auth_revoke)" />
-    </category>
-    <category label="30200">
-        <setting label="30202" type="lsep"/>
-        <setting id="fanart_tv_client_id" type="text" label="30203" default="fa836e1c874ba95ab08a14ee88e05565"/>
-    </category>
-    <category label="Menus">
-        <setting label="" type="lsep"/>
-        <setting id="show_telegram_menu" type="bool" label="Show Telegram Menu" default="false"/>
-    </category>
+<?xml version='1.0' encoding='utf-8'?>
+<settings version="1">
+    <section id="plugin.video.jacktook">
+        <category id="general_category" label="30712">
+            <group id="general" label="30712">
+                <setting id="torrent_enable" type="boolean" label="30713" help="">
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="torrent_client" type="string" label="30002" help="">
+                    <default>30714</default>
+                    <constraints>
+                        <options>
+                            <option label="30714">30714</option>
+                            <option label="30715">30715</option>
+                            <option label="30716">30716</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+            </group>
+            <group id="playback" label="30717"> 
+                <setting id="auto_play" type="boolean" label="30718" help=""> 
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="playnext_dialog_enabled" type="boolean" label="30719" help=""> 
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="playnext_time" type="integer" label="30720" help=""> 
+                    <default>50</default>
+                    <constraints>
+                        <minimum>5</minimum>
+                        <maximum>180</maximum>
+                        <step>1</step>
+                    </constraints>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                </setting>
+            </group>
+            <group id="cache" label="30723">
+                <setting id="cache_enabled" type="boolean" label="30721" help=""> 
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="cache_expiration" type="integer" label="30722" help=""> 
+                    <default>24</default>
+                    <constraints>
+                        <minimum>1</minimum>
+                        <step>1</step>
+                        <maximum>30</maximum>
+                    </constraints>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="cache_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="test33" type="action" label="30106" help=""> 
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=clear_all_cached)</data>
+                    <control type="button" format="action">
+                        <close>true</close>
+                    </control>
+                </setting>
+            </group>
+            <group id="update" label="30724">
+                <setting id="update" type="lsep" label="30723" help=""> 
+                </setting>
+                <setting id="update_addon" type="action" label="30724" help=""> 
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=addon_update)</data>
+                    <control type="button" format="action">
+                        <close>false</close>
+                    </control>
+                </setting>
+                <setting id="clear_cache_update" type="boolean" label="30806" help=""> 
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+            </group>
+        </category>
+        <category id="indexers_category" label="30020">
+            <group id="indexers" label="30725">
+                <setting id="indexers_total_results" type="integer" label="30029" help="">
+                    <default>60</default>
+                    <constraints>
+                        <minimum>10</minimum>
+                        <maximum>100</maximum>
+                        <step>10</step>
+                    </constraints>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                </setting>
+                <setting id="indexers_desc_length" type="integer" label="30026" help="">
+                    <default>100</default>
+                    <constraints>
+                        <minimum>50</minimum>
+                        <maximum>200</maximum>
+                        <step>10</step>
+                    </constraints>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                </setting>
+                <setting id="indexers_sort_by" type="labelenum" label="30726" help="">
+                    <default>30727</default>
+                    <constraints>
+                        <options>
+                            <option label="30728">30728</option>
+                            <option label="30729">30729</option>
+                            <option label="30727">30727</option>
+                            <option label="30730">30730</option>
+                            <option label="30731">30731</option>
+                            <option label="30732">30732</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="filter_by_episode" type="boolean" label="30710" help="">
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+            </group>
+            <group id="torrentio" label="30733">
+                <setting id="torrentio_enabled" type="boolean" label="30734" help="">
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="torrentio_host" type="string" label="30025" help="">
+                    <default>30735</default>
+                    <constraints>
+                        <allowempty>false</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30735</heading>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="torrentio_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="torrentio_priority_lang" type="labelenum" label="30736" help="">
+                    <default>30732</default>
+                    <constraints>
+                        <options>
+                            <option label="30737">30737</option>
+                            <option label="30738">30738</option>
+                            <option label="30739">30739</option>
+                            <option label="30740">30740</option>
+                            <option label="30741">30741</option>
+                            <option label="30742">30742</option>
+                            <option label="30743">30743</option>
+                            <option label="30744">30744</option>
+                            <option label="30745">30745</option>
+                            <option label="30746">30746</option>
+                            <option label="30747">30747</option>
+                            <option label="30748">30748</option>
+                            <option label="30749">30749</option>
+                            <option label="30750">30750</option>
+                            <option label="30751">30751</option>
+                            <option label="30752">30752</option>
+                            <option label="30753">30753</option>
+                            <option label="30754">30754</option>
+                            <option label="30755">30755</option>
+                            <option label="30756">30756</option>
+                            <option label="30757">30757</option>
+                            <option label="30758">30758</option>
+                            <option label="30759">30759</option>
+                            <option label="30760">30760</option>
+                            <option label="30761">30761</option>
+                            <option label="30762">30762</option>
+                            <option label="30763">30763</option>
+                            <option label="30764">30764</option>
+                            <option label="30765">30765</option>
+                            <option label="30732">30732</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="torrentio_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="torrentio_providers" type="action" label="30766" help="">
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=torrentio_selection)</data>
+                    <control type="button" format="action">
+                        <close>false</close>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="torrentio_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="jackgram" label="30767">
+                <setting id="jackgram_enabled" type="boolean" label="30734" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="jackgram_host" type="string" label="30768" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="jackgram_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="elfhosted" label="30769">
+                <setting id="elfhosted_enabled" type="boolean" label="30734" help="">
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="elfhosted_host" type="string" label="30025" help="">
+                    <default>30770</default>
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="elfhosted_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="zilean" label="30771">
+                <setting id="zilean_enabled" type="boolean" label="30734" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="zilean_host" type="string" label="30772" help="">
+                    <default>30773</default>
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="zilean_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="zilean_timeout" type="integer" label="30774" help="">
+                    <default>10</default>
+                    <constraints>
+                        <minimum>1</minimum>
+                        <maximum>30</maximum>
+                        <step>1</step>
+                    </constraints>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="zilean_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="jackett" label="30775">
+                <setting id="jackett_enabled" type="boolean" label="30734" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="jackett_host" type="string" label="30025" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="jackett_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="jackett_apikey" type="string" label="30023" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="jackett_enabled">true</condition>                        
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="jackett_timeout" type="integer" label="30030" help="">
+                    <default>25</default>
+                    <constraints>
+                        <minimum>1</minimum>
+                        <maximum>30</maximum>
+                        <step>1</step>
+                    </constraints>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="jackett_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="prowlarr" label="30776">
+                <setting id="prowlarr_enabled" type="boolean" label="30734" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="prowlarr_host" type="string" label="30052" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="prowlarr_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="prowlarr_apikey" type="string" label="30051" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="prowlarr_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="prowlarr_indexer_ids" type="string" label="30053" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="prowlarr_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="prowlarr_timeout" type="integer" label="30031" help="">
+                    <default>25</default>
+                    <constraints>
+                        <minimum>1</minimum>
+                        <maximum>30</maximum>
+                        <step>1</step>
+                    </constraints>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="prowlarr_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="mediafusion" label="30777">
+                <setting id="mediafusion_enabled" type="boolean" label="30734" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="mediafusion_host" type="string" label="30052" help="">
+                    <default>30778</default>
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="mediafusion_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="mediafusion_manifest_url" type="string" label="30779" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="mediafusion_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="jacktookburst" label="30780">
+                <setting id="jacktookburst_enabled" type="boolean" label="30734" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="burst_config" type="action" label="30781" help="">
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=open_burst_config)</data>
+                    <control type="button" format="action">
+                        <close>false</close>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="jacktookburst_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+        </category>
+        <category id="debrid" label="30150">
+            <group id="real_debrid" label="30152">
+                <setting id="real_debrid_enabled" type="boolean" label="30734" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="real_debid_authorized" type="boolean" label="" help="" visible="false">
+                    <default>false</default>
+                    <control type="toggle" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="real_debrid_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="real_debrid_user" type="string" label="30782" help="" visible="eq(-1,true)">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="real_debrid_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="real_debrid_token" type="string" label="30154" help="" visible="false">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="real_debrid_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="real_debrid_auth" type="action" label="30783" help="">
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=rd_auth)</data>
+                    <control type="button" format="action">
+                        <close>false</close>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="real_debrid_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="real_debrid_remove_auth" type="action" label="30784" help="">
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=rd_remove_auth)</data>
+                    <control type="button" format="action">
+                        <close>false</close>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="real_debrid_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="premiumize" label="30785">
+                <setting id="premiumize_enabled" type="boolean" label="30786" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="premiumize_token" type="string" label="30787" help="" visible="false">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="premiumize_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="premiumize_auth" type="action" label="30783" help="">
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=pm_auth)</data>
+                    <control type="button" format="action">
+                        <close>false</close>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="premiumize_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="torbox" label="30788">
+                <setting id="torbox_enabled" type="boolean" label="30786" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="torbox_token" type="string" label="30787" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="torbox_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="easydebrid" label="30789">
+                <setting id="easydebrid_enabled" type="boolean" label="30786" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="easydebrid_token" type="string" label="30787" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="easydebrid_enabled">true</condition>
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="uncached" label="30790">
+                <setting id="show_uncached" type="boolean" label="30791" help="">
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+            </group>
+        </category>
+        <category id="tmdb_category" label="30100">
+            <group id="tmdb" label="30102">
+                <setting id="tmdb_apikey" type="string" label="30103" help="">
+                    <default />
+                    <control type="edit" format="string" />
+                </setting>
+                <setting id="kodi_language" type="boolean" label="30792" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+            </group>
+        </category>
+        <category id="trakt_category" label="30793">
+            <group id="trakt" label="30794">
+                <setting id="trakt_auth" type="action" label="30783" help="">
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=trakt_auth)</data>
+                    <control type="button" format="action">
+                        <close>false</close>
+                    </control>
+                </setting>
+                <setting id="trakt_expires" type="string" label="30795" help="" visible="false">
+                    <default>0</default>
+                    <control type="edit" format="string" />
+                </setting>
+                <setting id="trakt_refresh" type="string" label="30796" help="" visible="false">
+                    <default>0</default>
+                    <control type="edit" format="string" />
+                </setting>
+                <setting id="trakt_token" type="string" label="30797" help="" visible="false">
+                    <default>0</default>
+                    <control type="edit" format="string" />
+                </setting>
+                <setting id="trakt_user" type="string" label="30782" help="" visible="false">
+                    <default>0</default>
+                    <control type="edit" format="string" />
+                </setting>
+                <setting id="trakt_client" type="string" label="30798" help="">
+                    <default>30799</default>
+                    <control type="edit" format="string" />
+                </setting>
+                <setting id="trakt_secret" type="string" label="30800" help="">
+                    <default>30801</default>
+                    <control type="edit" format="string" />
+                </setting>
+                <setting id="trakt_logout" type="action" label="30802" help="">
+                    <data>RunPlugin(plugin://plugin.video.jacktook/?action=trakt_auth_revoke)</data>
+                    <control type="button" format="action">
+
+                    </control>
+                </setting>
+            </group>
+        </category>
+        <category id="fanart" label="30200">
+            <group id="fanart_tv" label="30202">
+                <setting id="fanart_tv_client_id" type="string" label="30203" help="">
+                    <default>30803</default>
+                    <control type="edit" format="string" />
+                </setting>
+            </group>
+        </category>
+        <category id="menus" label="30804">
+            <group id="telegram" label="">
+                <setting id="show_telegram_menu" type="boolean" label="30805" help="">
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+            </group>
+        </category>
+    </section>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -451,7 +451,7 @@
                 </setting>
             </group>
             <group id="premiumize" label="30785">
-                <setting id="premiumize_enabled" type="boolean" label="30786" help="">
+                <setting id="premiumize_enabled" type="boolean" label="30734" help="">
                     <default>false</default>
                     <control type="toggle" />
                 </setting>
@@ -478,7 +478,7 @@
                 </setting>
             </group>
             <group id="torbox" label="30788">
-                <setting id="torbox_enabled" type="boolean" label="30786" help="">
+                <setting id="torbox_enabled" type="boolean" label="30734" help="">
                     <default>false</default>
                     <control type="toggle" />
                 </setting>
@@ -493,7 +493,7 @@
                 </setting>
             </group>
             <group id="easydebrid" label="30789">
-                <setting id="easydebrid_enabled" type="boolean" label="30786" help="">
+                <setting id="easydebrid_enabled" type="boolean" label="30734" help="">
                     <default>false</default>
                     <control type="toggle" />
                 </setting>
@@ -520,9 +520,83 @@
                     <default />
                     <control type="edit" format="string" />
                 </setting>
-                <setting id="kodi_language" type="boolean" label="30792" help="">
-                    <default>false</default>
-                    <control type="toggle" />
+                <setting id="language" type="integer" label="42418" help="42419">
+                    <default>18</default>
+                    <constraints>
+                        <options>
+                            <option label="40000">0</option>
+                            <option label="40001">1</option>
+                            <option label="40002">2</option>
+                            <option label="40003">3</option>
+                            <option label="40004">4</option>
+                            <option label="40005">5</option>
+                            <option label="40006">6</option>
+                            <option label="40007">7</option>
+                            <option label="40008">8</option>
+                            <option label="40009">9</option>
+                            <option label="40010">10</option>
+                            <option label="40011">11</option>
+                            <option label="40012">12</option>
+                            <option label="40013">13</option>
+                            <option label="40014">14</option>
+                            <option label="40015">15</option>
+                            <option label="40016">16</option>
+                            <option label="40017">17</option>
+                            <option label="40018">18</option>
+                            <option label="40019">19</option>
+                            <option label="40020">20</option>
+                            <option label="40021">21</option>
+                            <option label="40022">22</option>
+                            <option label="40023">23</option>
+                            <option label="40024">24</option>
+                            <option label="40025">25</option>
+                            <option label="40026">26</option>
+                            <option label="40027">27</option>
+                            <option label="40028">28</option>
+                            <option label="40029">29</option>
+                            <option label="40030">30</option>
+                            <option label="40031">31</option>
+                            <option label="40030">32</option>
+                            <option label="40033">33</option>
+                            <option label="40034">34</option>
+                            <option label="40035">35</option>
+                            <option label="40036">36</option>
+                            <option label="40037">37</option>
+                            <option label="40038">38</option>
+                            <option label="40039">39</option>
+                            <option label="40040">40</option>
+                            <option label="40041">41</option>
+                            <option label="40042">42</option>
+                            <option label="40043">43</option>
+                            <option label="40044">44</option>
+                            <option label="40045">45</option>
+                            <option label="40046">46</option>
+                            <option label="40047">47</option>
+                            <option label="40048">48</option>
+                            <option label="40049">49</option>
+                            <option label="40050">50</option>
+                            <option label="40051">51</option>
+                            <option label="40052">52</option>
+                            <option label="40053">53</option>
+                            <option label="40054">54</option>
+                            <option label="40055">55</option>
+                            <option label="40056">56</option>
+                            <option label="40057">57</option>
+                            <option label="40058">58</option>
+                            <option label="40059">59</option>
+                            <option label="40060">60</option>
+                            <option label="40061">61</option>
+                            <option label="40062">62</option>
+                            <option label="40063">63</option>
+                            <option label="40064">64</option>
+                            <option label="40065">65</option>
+                            <option label="40066">66</option>
+                            <option label="40067">67</option>
+                        </options>
+                    </constraints>
+                    <control type="list" format="string">
+                        <heading>42418</heading>
+                    </control>
                 </setting>
             </group>
         </category>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,12 +8,12 @@
                     <control type="toggle" />
                 </setting>
                 <setting id="torrent_client" type="string" label="30002" help="">
-                    <default>30714</default>
+                    <default>Jacktorr</default>
                     <constraints>
                         <options>
-                            <option label="30714">30714</option>
-                            <option label="30715">30715</option>
-                            <option label="30716">30716</option>
+                            <option label="30714">Jacktorr</option>
+                            <option label="30715">Torrest</option>
+                            <option label="30716">Elementum</option>
                         </options>
                     </constraints>
                     <control type="spinner" format="string" />
@@ -107,16 +107,16 @@
                         <popup>false</popup>
                     </control>
                 </setting>
-                <setting id="indexers_sort_by" type="labelenum" label="30726" help="">
+                <setting id="indexers_sort_by" type="string" label="30726" help="">
                     <default>30727</default>
                     <constraints>
                         <options>
-                            <option label="30728">30728</option>
-                            <option label="30729">30729</option>
-                            <option label="30727">30727</option>
-                            <option label="30730">30730</option>
-                            <option label="30731">30731</option>
-                            <option label="30732">30732</option>
+                            <option label="30728">Seeds</option>
+                            <option label="30729">Size</option>
+                            <option label="30727">Quality</option>
+                            <option label="30730">Cached</option>
+                            <option label="30731">Date</option>
+                            <option label="30732">None</option>
                         </options>
                     </constraints>
                     <control type="spinner" format="string" />
@@ -132,7 +132,7 @@
                     <control type="toggle" />
                 </setting>
                 <setting id="torrentio_host" type="string" label="30025" help="">
-                    <default>30735</default>
+                    <default>https://torrentio.strem.fun/</default>
                     <constraints>
                         <allowempty>false</allowempty>
                     </constraints>
@@ -145,40 +145,40 @@
                         </dependency>
                     </dependencies>
                 </setting>
-                <setting id="torrentio_priority_lang" type="labelenum" label="30736" help="">
+                <setting id="torrentio_priority_lang" type="string" label="30736" help="">
                     <default>30732</default>
                     <constraints>
                         <options>
-                            <option label="30737">30737</option>
-                            <option label="30738">30738</option>
-                            <option label="30739">30739</option>
-                            <option label="30740">30740</option>
-                            <option label="30741">30741</option>
-                            <option label="30742">30742</option>
-                            <option label="30743">30743</option>
-                            <option label="30744">30744</option>
-                            <option label="30745">30745</option>
-                            <option label="30746">30746</option>
-                            <option label="30747">30747</option>
-                            <option label="30748">30748</option>
-                            <option label="30749">30749</option>
-                            <option label="30750">30750</option>
-                            <option label="30751">30751</option>
-                            <option label="30752">30752</option>
-                            <option label="30753">30753</option>
-                            <option label="30754">30754</option>
-                            <option label="30755">30755</option>
-                            <option label="30756">30756</option>
-                            <option label="30757">30757</option>
-                            <option label="30758">30758</option>
-                            <option label="30759">30759</option>
-                            <option label="30760">30760</option>
-                            <option label="30761">30761</option>
-                            <option label="30762">30762</option>
-                            <option label="30763">30763</option>
-                            <option label="30764">30764</option>
-                            <option label="30765">30765</option>
-                            <option label="30732">30732</option>
+                            <option label="30737">GB</option>
+                            <option label="30738">JP</option>
+                            <option label="30739">RU</option>
+                            <option label="30740">IT</option>
+                            <option label="30741">PT</option>
+                            <option label="30742">ES</option>
+                            <option label="30743">MX</option>
+                            <option label="30744">KR</option>
+                            <option label="30745">CN</option>
+                            <option label="30746">TW</option>
+                            <option label="30747">FR</option>
+                            <option label="30748">DE</option>
+                            <option label="30749">NL</option>
+                            <option label="30750">IN</option>
+                            <option label="30751">PL</option>
+                            <option label="30752">LT</option>
+                            <option label="30753">CZ</option>
+                            <option label="30754">SK</option>
+                            <option label="30755">SI</option>
+                            <option label="30756">HU</option>
+                            <option label="30757">RO</option>
+                            <option label="30758">HR</option>
+                            <option label="30759">UA</option>
+                            <option label="30760">GR</option>
+                            <option label="30761">DK</option>
+                            <option label="30762">FI</option>
+                            <option label="30763">SE</option>
+                            <option label="30764">NO</option>
+                            <option label="30765">TR</option>
+                            <option label="30732">None</option>
                         </options>
                     </constraints>
                     <control type="spinner" format="string" />
@@ -221,7 +221,7 @@
                     <control type="toggle" />
                 </setting>
                 <setting id="elfhosted_host" type="string" label="30025" help="">
-                    <default>30770</default>
+                    <default>https://torrentio.elfhosted.com/</default>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -236,7 +236,7 @@
                     <control type="toggle" />
                 </setting>
                 <setting id="zilean_host" type="string" label="30772" help="">
-                    <default>30773</default>
+                    <default>https://zilean.elfhosted.com</default>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -356,7 +356,7 @@
                     <control type="toggle" />
                 </setting>
                 <setting id="mediafusion_host" type="string" label="30052" help="">
-                    <default>30778</default>
+                    <default>https://mediafusion.elfhosted.com</default>
                     <control type="edit" format="string" />
                     <dependencies>
                         <dependency type="visible">
@@ -548,11 +548,11 @@
                     <control type="edit" format="string" />
                 </setting>
                 <setting id="trakt_client" type="string" label="30798" help="">
-                    <default>30799</default>
+                    <default>1038ef327e86e7f6d39d80d2eb5479bff66dd8394e813c5e0e387af0f84d89fb</default>
                     <control type="edit" format="string" />
                 </setting>
                 <setting id="trakt_secret" type="string" label="30800" help="">
-                    <default>30801</default>
+                    <default>8d27a92e1d17334dae4a0590083a4f26401cb8f721f477a79fd3f218f8534fd1</default>
                     <control type="edit" format="string" />
                 </setting>
                 <setting id="trakt_logout" type="action" label="30802" help="">
@@ -566,7 +566,7 @@
         <category id="fanart" label="30200">
             <group id="fanart_tv" label="30202">
                 <setting id="fanart_tv_client_id" type="string" label="30203" help="">
-                    <default>30803</default>
+                    <default>fa836e1c874ba95ab08a14ee88e05565</default>
                     <control type="edit" format="string" />
                 </setting>
             </group>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -16,6 +16,11 @@
                             <option label="30716">Elementum</option>
                         </options>
                     </constraints>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="torrent_enable">true</condition>
+                        </dependency>
+                    </dependencies>
                     <control type="spinner" format="string" />
                 </setting>
             </group>
@@ -61,7 +66,7 @@
                         </dependency>
                     </dependencies>
                 </setting>
-                <setting id="test33" type="action" label="30106" help=""> 
+                <setting id="clear_all_cached" type="action" label="30106" help=""> 
                     <data>RunPlugin(plugin://plugin.video.jacktook/?action=clear_all_cached)</data>
                     <control type="button" format="action">
                         <close>true</close>
@@ -71,7 +76,7 @@
             <group id="update" label="30724">
                 <setting id="update" type="lsep" label="30723" help=""> 
                 </setting>
-                <setting id="update_addon" type="action" label="30724" help=""> 
+                <setting id="addon_update" type="action" label="30724" help=""> 
                     <data>RunPlugin(plugin://plugin.video.jacktook/?action=addon_update)</data>
                     <control type="button" format="action">
                         <close>false</close>
@@ -203,7 +208,7 @@
             <group id="jackgram" label="30767">
                 <setting id="jackgram_enabled" type="boolean" label="30734" help="">
                     <default>false</default>
-                    <control type="toggle" />
+                    <control type="toggle"/>
                 </setting>
                 <setting id="jackgram_host" type="string" label="30768" help="">
                     <default/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -398,7 +398,8 @@
                     <default>false</default>
                     <control type="toggle" />
                 </setting>
-                <setting id="real_debid_authorized" type="boolean" label="" help="" visible="false">
+                <setting id="real_debid_authorized" type="boolean" label="" help="">
+                    <visible>false</visible>
                     <default>false</default>
                     <control type="toggle" />
                     <dependencies>
@@ -407,7 +408,7 @@
                         </dependency>
                     </dependencies>
                 </setting>
-                <setting id="real_debrid_user" type="string" label="30782" help="" visible="eq(-1,true)">
+                <setting id="real_debrid_user" type="string" label="30782" help="">
                     <default />
                     <control type="edit" format="string" />
                     <dependencies>
@@ -416,7 +417,8 @@
                         </dependency>
                     </dependencies>
                 </setting>
-                <setting id="real_debrid_token" type="string" label="30154" help="" visible="false">
+                <setting id="real_debrid_token" type="string" label="30154" help="">
+                    <visible>false</visible>
                     <default />
                     <control type="edit" format="string" />
                     <dependencies>
@@ -453,7 +455,8 @@
                     <default>false</default>
                     <control type="toggle" />
                 </setting>
-                <setting id="premiumize_token" type="string" label="30787" help="" visible="false">
+                <setting id="premiumize_token" type="string" label="30787" help="">
+                    <visible>false</visible>
                     <default />
                     <control type="edit" format="string" />
                     <dependencies>
@@ -531,19 +534,23 @@
                         <close>false</close>
                     </control>
                 </setting>
-                <setting id="trakt_expires" type="string" label="30795" help="" visible="false">
+                <setting id="trakt_expires" type="string" label="30795" help="">
+                    <visible>false</visible>
                     <default>0</default>
                     <control type="edit" format="string" />
                 </setting>
-                <setting id="trakt_refresh" type="string" label="30796" help="" visible="false">
+                <setting id="trakt_refresh" type="string" label="30796" help="">
+                    <visible>false</visible>
                     <default>0</default>
                     <control type="edit" format="string" />
                 </setting>
-                <setting id="trakt_token" type="string" label="30797" help="" visible="false">
+                <setting id="trakt_token" type="string" label="30797" help="">
+                    <visible>false</visible>
                     <default>0</default>
                     <control type="edit" format="string" />
                 </setting>
-                <setting id="trakt_user" type="string" label="30782" help="" visible="false">
+                <setting id="trakt_user" type="string" label="30782" help="">
+                    <visible>false</visible>
                     <default>0</default>
                     <control type="edit" format="string" />
                 </setting>


### PR DESCRIPTION
This pull request introduces the same language and region selection for TMDb as used in the TMDb Helper add-on. This enhancement addresses issues with selecting languages, which can result in different titles depending on the country.

To implement this, I updated the format of settings.xml. The reasons for this update are as follows:
	•	Compatibility: The current format was deprecated in Kodi 19.
	•	Improved Usability: By utilizing the help attribute, inline documentation is provided, enabling users to understand each setting without relying on external guides or trial and error.
	•	Enhanced Functionality: The new format supports multiple selections in lists, which opens the door for additional improvements, such as removing the need for custom dialogs when choosing Torrentio providers in the future. It also supports the list control required to select language and region.