### PR TITLE
Support for searching season packs 

### DIFF
--- a/lib/clients/jackett.py
+++ b/lib/clients/jackett.py
@@ -59,7 +59,12 @@ class Jackett(BaseClient):
             if response.status_code != 200:
                 self.notification(f"{translation(30229)} ({response.status_code})")
                 return None
-            return self.parse_response(response)
+            if ((mode == "tv") and (episode != None)):
+                episode_list=self.parse_response(response)
+                season_list=self.search(query, mode, season, None, categories, additional_params)
+                return season_list + episode_list
+            else:
+                return self.parse_response(response)
         except Exception as e:
             self.handle_exception(f"{translation(30229)}: {str(e)}")
             return None

--- a/lib/clients/jackett.py
+++ b/lib/clients/jackett.py
@@ -63,12 +63,7 @@ class Jackett(BaseClient):
             if response.status_code != 200:
                 self.notification(f"{translation(30229)} ({response.status_code})")
                 return None
-            if ((mode == "tv") and (episode != None)):
-                episode_list=self.parse_response(response)
-                season_list=self.search(query, mode, season, None, categories, additional_params)
-                return season_list + episode_list
-            else:
-                return self.parse_response(response)
+            return self.parse_response(response)
         except Exception as e:
             self.handle_exception(f"{translation(30229)}: {str(e)}")
             return None

--- a/lib/clients/jackett.py
+++ b/lib/clients/jackett.py
@@ -1,7 +1,7 @@
 from lib.clients.base import BaseClient
 from lib.clients.base import TorrentStream
 
-from lib.utils.kodi.utils import translation
+from lib.utils.kodi.utils import get_setting, translation
 from lib.utils.parsers import xmltodict
 from lib.utils.kodi.settings import get_jackett_timeout
 
@@ -27,7 +27,11 @@ class Jackett(BaseClient):
     ) -> str:
         url = f"{self.base_url}&q={query}"
         if mode == "tv":
-            url += f"&t=tvsearch&season={season}&ep={episode}"
+            url += "&t=tvsearch"
+            if get_setting("include_season_packs"):
+                url += f"&season={season}"
+            else:
+                url += f"&season={season}&ep={episode}"
         elif mode == "movies":
             url += "&t=movie"
         else:

--- a/lib/clients/prowlarr.py
+++ b/lib/clients/prowlarr.py
@@ -1,5 +1,5 @@
 from lib.clients.base import BaseClient, TorrentStream
-from lib.utils.kodi.utils import translation
+from lib.utils.kodi.utils import get_setting, translation
 from lib.utils.kodi.settings import get_prowlarr_timeout
 from typing import List, Optional, Any, Callable
 
@@ -27,7 +27,9 @@ class Prowlarr(BaseClient):
             params = {"query": query, "type": "search"}
             if mode == "tv":
                 params["categories"] = [5000, 8000]
-                if season is not None and episode is not None:
+                if get_setting("include_season_packs"):
+                    params["query"] = f"{query} S{int(season):02d}"
+                else:
                     params["query"] = f"{query} S{int(season):02d}E{int(episode):02d}"
             elif mode == "movies":
                 params["categories"] = [2000, 8000]

--- a/lib/jacktook/client.py
+++ b/lib/jacktook/client.py
@@ -3,8 +3,9 @@ from .providers import (
     burst_search,
     burst_search_episode,
     burst_search_movie,
+    burst_search_season,
 )
-from lib.utils.kodi.utils import convert_size_to_bytes
+from lib.utils.kodi.utils import convert_size_to_bytes, get_setting
 from typing import List, Optional, Dict, Any, Callable
 
 
@@ -23,7 +24,10 @@ class Burst(BaseClient):
     ) -> Optional[List[TorrentStream]]:
         try:
             if mode == "tv" or media_type == "tv":
-                results = burst_search_episode(tmdb_id, query, season, episode)
+                if get_setting("include_season_packs"):
+                    results = burst_search_season(tmdb_id, query, season)
+                else:
+                    results = burst_search_episode(tmdb_id, query, season, episode)
             elif mode == "movies" or media_type == "movies":
                 results = burst_search_movie(tmdb_id, query)
             else:

--- a/lib/utils/general/processors.py
+++ b/lib/utils/general/processors.py
@@ -39,6 +39,8 @@ class BaseProcessBuilder:
             r"season",
             r"the\.complete",
             r"complete",
+            r"integrale",
+            rf"Saison {season_num}"
             r"S(\d{2})E(\d{2})-(\d{2})",
             rf"\.season\.{season_num}\.",
             rf"\.season{season_num}\.",

--- a/lib/utils/general/processors.py
+++ b/lib/utils/general/processors.py
@@ -132,8 +132,6 @@ class PreProcessBuilder(BaseProcessBuilder):
             rf"{season_fill}x{episode_fill}",  # XXxXX format
             rf"\.S{season_fill}E{episode_fill}",  # .SXXEXX format
             rf"\sS{season_fill}E{episode_fill}\s",  # season and episode surrounded by spaces
-            rf"\sS{season_fill}\s",  # season surrounded by spaces
-            rf"\.S{season_fill}\.",  # season surrounded by dots
             r"Cap\.",  # match "Cap."
         ]
 

--- a/lib/utils/general/processors.py
+++ b/lib/utils/general/processors.py
@@ -131,6 +131,8 @@ class PreProcessBuilder:
             rf"{season_fill}x{episode_fill}",  # XXxXX format
             rf"\.S{season_fill}E{episode_fill}",  # .SXXEXX format
             rf"\sS{season_fill}E{episode_fill}\s",  # season and episode surrounded by spaces
+            rf"\sS{season_fill}\s",  # season surrounded by spaces
+            rf"\.S{season_fill}\.",  # season surrounded by dots
             r"Cap\.",  # match "Cap."
         ]
 

--- a/lib/utils/general/processors.py
+++ b/lib/utils/general/processors.py
@@ -6,6 +6,7 @@ from lib.clients.base import TorrentStream
 
 import xbmc
 
+
 class Quality(Enum):
     LOW = ("480p", "[B][COLOR orange]480p[/COLOR][/B]")
     MEDIUM = ("720p", "[B][COLOR orange]720p[/COLOR][/B]")
@@ -22,40 +23,26 @@ class SortField(Enum):
     CACHED = "isCached"
 
 
-class PostProcessBuilder:
+class BaseProcessBuilder:
     def __init__(self, results: List[TorrentStream]):
         self.results: List[TorrentStream] = results
 
-    def check_season_pack(self, season: int) -> "PostProcessBuilder":
-        season_patterns = self._generate_season_patterns(season)
-        for res in self.results:
-            res.isPack = self._matches_any_pattern(res.title, season_patterns)
-        return self
-
-    def _generate_season_patterns(self, season_num: int) -> List[str]:
+    def get_season_pack_patterns(self, season_num: int) -> list:
         season_fill = f"{int(season_num):02}"
-
         return [
-            # Season as ".S{season_num}." or ".S{season_fill}."
             rf"\.S{season_num}\.",
             rf"\.S{season_fill}\.",
-            # Season as " S{season_num} " or " S{season_fill} "
             rf"\sS{season_num}\s",
             rf"\sS{season_fill}\s",
-            # Season as ".{season_num}.season" (like .1.season, .01.season)
             rf"\.{season_num}\.season",
-            # "total.season" or "season" or "the.complete"
             r"total\.season",
             r"season",
             r"the\.complete",
             r"complete",
-            # Pattern to detect episode ranges like S02E01-02
             r"S(\d{2})E(\d{2})-(\d{2})",
-            # Season as ".season.{season_num}." or ".season.{season_fill}."
             rf"\.season\.{season_num}\.",
             rf"\.season{season_num}\.",
             rf"\.season\.{season_fill}\.",
-            # Handle cases "s1 to {season_num}", "s1 thru {season_num}", etc.
             rf"s1 to {season_num}",
             rf"s1 to s{season_num}",
             rf"s01 to {season_fill}",
@@ -66,9 +53,19 @@ class PostProcessBuilder:
             rf"s01 thru s{season_fill}",
         ]
 
-    def _matches_any_pattern(self, title: str, patterns: List[str]) -> bool:
-        combined_pattern = "|".join(patterns)
-        return bool(re.search(combined_pattern, title))
+    def get_results(self) -> List[TorrentStream]:
+        return self.results
+
+
+class PostProcessBuilder(BaseProcessBuilder):
+    def __init__(self, results: List[TorrentStream]):
+        super().__init__(results)
+
+    def check_season_pack(self, season: int) -> "PostProcessBuilder":
+        season_patterns = self.get_season_pack_patterns(season)
+        for res in self.results:
+            res.isPack = bool(re.search("|".join(season_patterns), res.title))
+        return self
 
     def sort_results(self) -> "PostProcessBuilder":
         sort_by = get_setting("indexers_sort_by")
@@ -85,34 +82,20 @@ class PostProcessBuilder:
         self.results = self.results[:limit]
         return self
 
-    def remove_duplicates(self) -> "PostProcessBuilder":
-        seen_values: List[str] = []
-        unique_results: List[TorrentStream] = []
-        for res in self.results:
-            if res.infoHash not in seen_values:
-                unique_results.append(res)
-                seen_values.append(res.infoHash)
-        self.results = unique_results
-        return self
 
-    def get_results(self) -> List[TorrentStream]:
-        return self.results
-
-
-class PreProcessBuilder:
+class PreProcessBuilder(BaseProcessBuilder):
     def __init__(self, results: List[TorrentStream]):
-        self.results: List[TorrentStream] = results
+        super().__init__(results)
 
     def remove_duplicates(self) -> "PreProcessBuilder":
         seen_values: List[str] = []
         unique_results: List[TorrentStream] = []
         for res in self.results:
-            if res.infoHash not in seen_values or res.guid not in seen_values:
+            key = getattr(res, "infoHash", None) or getattr(res, "guid", None)
+            if key and key not in seen_values:
                 unique_results.append(res)
-                seen_values.append(res.infoHash)
-                seen_values.append(res.guid)
+                seen_values.append(key)
         self.results = unique_results
-        kodilog(f"Removed duplicates: {self.results}", level=xbmc.LOGDEBUG)
         return self
 
     def filter_torrent_sources(self) -> "PreProcessBuilder":
@@ -120,9 +103,25 @@ class PreProcessBuilder:
         kodilog(f"Filtered torrent sources: {self.results}", level=xbmc.LOGDEBUG)
         return self
 
-    def filter_by_episode(
+    def filter_season_packs(self, season_num: int) -> List[TorrentStream]:
+        season_patterns = self.get_season_pack_patterns(season_num)
+        return [
+            res
+            for res in self.results
+            if re.search("|".join(season_patterns), res.title)
+        ]
+
+    def filter_sources(
         self, episode_name: str, episode_num: int, season_num: int
     ) -> "PreProcessBuilder":
+
+        include_season_packs = get_setting("include_season_packs")
+        season_pack_results: List[TorrentStream] = []
+
+        if include_season_packs:
+            kodilog("Including season packs in filtering")
+            season_pack_results = self.filter_season_packs(season_num)
+
         episode_fill = f"{int(episode_num):02}"
         season_fill = f"{int(season_num):02}"
 
@@ -139,11 +138,16 @@ class PreProcessBuilder:
         if episode_name:
             patterns.append(episode_name)
 
-        combined_pattern = "|".join(patterns)
-        self.results = [
-            res for res in self.results if re.search(combined_pattern, res.title)
+        episode_results = [
+            res for res in self.results if re.search("|".join(patterns), res.title)
         ]
-        kodilog(f"Filtered by episode: {self.results}", level=xbmc.LOGDEBUG)
+
+        # Combine both lists
+        self.results = season_pack_results + episode_results
+
+        kodilog(
+            f"Filtered by episode and season packs: {self.results}", level=xbmc.LOGDEBUG
+        )
         return self
 
     def filter_by_quality(self) -> "PreProcessBuilder":
@@ -176,6 +180,3 @@ class PreProcessBuilder:
         kodilog(f"Quality buckets: {self.results}", level=xbmc.LOGDEBUG)
 
         return self
-
-    def get_results(self) -> List[TorrentStream]:
-        return self.results

--- a/lib/utils/general/utils.py
+++ b/lib/utils/general/utils.py
@@ -829,8 +829,8 @@ def pre_process(
     if get_setting("stremio_enabled") and get_setting("torrent_enable"):
         kodilog("Filtering torrent sources")
         builder.filter_torrent_sources()
-    if mode == "tv" and get_setting("filter_by_episode"):
-        builder.filter_by_episode(episode_name, episode, season)
+    if mode == "tv":
+        builder.filter_sources(episode_name, episode, season)
     builder.filter_by_quality()
     return builder.get_results()
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -332,7 +332,7 @@ msgid "Drop torrent"
 msgstr ""
 
 msgctxt "#30710"
-msgid "Filter TV Shows by Season and Episode"
+msgid "Include Season Packs"
 msgstr ""
 
 msgctxt "#30711"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -304,8 +304,8 @@ msgid "Drop torrent"
 msgstr "Drop torrent"
 
 msgctxt "#30710"
-msgid "Filter TV Shows by Season and Episode"
-msgstr "Filtrar programas de TV por temporada e episódio"
+msgid "Include Season Packs"
+msgstr "Incluir pacotes de temporadas"
 
 msgctxt "#30801"
 msgid "Zilean server address (include port if required)."

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -304,8 +304,8 @@ msgid "Drop torrent"
 msgstr "Drop torrent"
 
 msgctxt "#30710"
-msgid "Filter TV Shows by Season and Episode"
-msgstr "Filtrar programas de TV por temporada e episódio"
+msgid "Include Season Packs"
+msgstr "Incluir pacotes de temporadas"
 
 msgctxt "#30801"
 msgid "Zilean server address (include port if required)."

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -316,8 +316,8 @@ msgid "Drop torrent"
 msgstr "Drop torrent"
 
 msgctxt "#30710"
-msgid "Filter TV Shows by Season and Episode"
-msgstr "Filtrar programas de TV por temporada y episodio"
+msgid "Include Season Packs"
+msgstr "Incluir Packs de Temporadas"
 
 msgctxt "#30711"
 msgid "Torrent Settings"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -365,7 +365,7 @@
                     </constraints>
                     <control type="spinner" format="string" />
                 </setting>
-                <setting id="filter_by_episode" type="boolean" label="30710" help="30812">
+                <setting id="include_season_packs" type="boolean" label="30710" help="">
                     <default>true</default>
                     <control type="toggle" />
                 </setting>


### PR DESCRIPTION
When using Jackett season packs are excluded.

This patch is a rudimentary fix.

It is the first time I have ever written python code. I tried to make the minimum changes possible without losing results.

The episode and season queries have many overlapping results because the season search includes individual episode results, but I noticed some results in the episode query that don't appear in the season query I tested. Otherwise it would be possible to just ignore the episode variable and return only results for the season with a single query.