### PR TITLE
feat(downloads): add manager and local downloads browser

### DIFF
--- a/lib/download_manager.py
+++ b/lib/download_manager.py
@@ -1,0 +1,108 @@
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class DownloadEntry:
+    id: str
+    name: str
+    dest_path: str
+    url: str
+    status: str = "downloading"
+    progress: int = 0
+    speed: int = 0
+    eta: int = 0
+    size: int = 0
+    downloaded: int = 0
+    thread: Optional[threading.Thread] = None
+    cancel_flag: bool = False
+
+
+class DownloadManager:
+    _instance: Optional["DownloadManager"] = None
+    _lock: threading.Lock = threading.Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._init()
+        return cls._instance
+
+    def _init(self):
+        self._registry: Dict[str, DownloadEntry] = {}
+        self._registry_lock = threading.Lock()
+
+    @property
+    def registry(self) -> Dict[str, DownloadEntry]:
+        with self._registry_lock:
+            return dict(self._registry)
+
+    def register(
+        self,
+        name: str,
+        dest_path: str,
+        url: str,
+        thread: Optional[threading.Thread] = None,
+    ) -> Optional[DownloadEntry]:
+        with self._registry_lock:
+            existing = self._registry.get(dest_path)
+            if existing and existing.status == "downloading":
+                return None
+            entry = DownloadEntry(
+                id=dest_path,
+                name=name,
+                dest_path=dest_path,
+                url=url,
+                thread=thread,
+            )
+            self._registry[dest_path] = entry
+            return entry
+
+    def update_progress(
+        self,
+        dest_path: str,
+        downloaded: int,
+        speed: int,
+        eta: int,
+        progress: int,
+        size: int,
+    ):
+        with self._registry_lock:
+            entry = self._registry.get(dest_path)
+            if entry:
+                entry.downloaded = downloaded
+                entry.speed = speed
+                entry.eta = eta
+                entry.progress = progress
+                entry.size = size
+
+    def set_status(self, dest_path: str, status: str):
+        with self._registry_lock:
+            entry = self._registry.get(dest_path)
+            if entry:
+                entry.status = status
+
+    def set_thread(self, dest_path: str, thread: Optional[threading.Thread]):
+        with self._registry_lock:
+            entry = self._registry.get(dest_path)
+            if entry:
+                entry.thread = thread
+
+    def get_entry(self, dest_path: str) -> Optional[DownloadEntry]:
+        with self._registry_lock:
+            return self._registry.get(dest_path)
+
+    def remove_entry(self, dest_path: str):
+        with self._registry_lock:
+            self._registry.pop(dest_path, None)
+
+    def list_entries(self) -> List[DownloadEntry]:
+        with self._registry_lock:
+            return list(self._registry.values())
+
+    def clear(self):
+        with self._registry_lock:
+            self._registry.clear()

--- a/lib/downloader.py
+++ b/lib/downloader.py
@@ -40,10 +40,12 @@ cancel_flag_cache = MemoryCache()
 
 def handle_download_file(params):
     destination = params.get("destination")
-    if not destination or not os.path.exists(destination):
+    if not destination:
         kodilog(f"[Downloader] Invalid download destination: {destination}")
         notification("Invalid download destination.")
         return
+
+    xbmcvfs.mkdirs(destination)
 
     url = params.get("url", "")
     file_name = normalize_file_name(params.get("file_name", ""), url)
@@ -213,7 +215,7 @@ class Downloader:
                 "speed": speed,
                 "eta": eta,
             }
-            with open(self.meta_path, "w") as f:
+            with open_file(self.meta_path, "w") as f:
                 json.dump(meta, f)
         except Exception as e:
             kodilog(f"[Downloader] Failed to write metadata: {str(e)}")
@@ -324,23 +326,24 @@ class Downloader:
 
         try:
             # Resume support — check temp file
-            if os.path.exists(self.temp_path):
-                downloaded = os.path.getsize(self.temp_path)
+            if xbmcvfs.exists(self.temp_path):
+                stat = xbmcvfs.Stat(self.temp_path)
+                downloaded = stat.st_size()
                 if downloaded < self.file_size:
                     self.headers["Range"] = f"bytes={downloaded}-"
                     file_mode = "ab"
                 elif downloaded >= self.file_size:
                     # Temp file is complete but not renamed yet
-                    if xbmcvfs.exists(self.temp_path):
-                        xbmcvfs.rename(self.temp_path, self.dest_path)
+                    xbmcvfs.rename(self.temp_path, self.dest_path)
                     self._write_metadata("completed", 100)
                     self._set_registry_status("completed")
                     notification(f"File already downloaded: {self.name}")
                     return
 
             # Also check if final file already exists
-            if os.path.exists(self.dest_path):
-                downloaded = os.path.getsize(self.dest_path)
+            if xbmcvfs.exists(self.dest_path):
+                stat = xbmcvfs.Stat(self.dest_path)
+                downloaded = stat.st_size()
                 if downloaded >= self.file_size:
                     self._write_metadata("completed", 100)
                     self._set_registry_status("completed")
@@ -450,11 +453,11 @@ def handle_pause_download(params, refresh=True):
         cancel_flag_cache.set(final_path, True)
         meta_path = final_path + ".jacktook.json"
         try:
-            if os.path.exists(meta_path):
-                with open(meta_path, "r") as f:
+            if xbmcvfs.exists(meta_path):
+                with open_file(meta_path, "r") as f:
                     meta = json.load(f)
                 meta["status"] = "paused"
-                with open(meta_path, "w") as f:
+                with open_file(meta_path, "w") as f:
                     json.dump(meta, f)
         except Exception as e:
             kodilog(f"[Downloader] Failed to update pause metadata: {str(e)}")
@@ -475,13 +478,13 @@ def resume_download(params):
     temp_path = final_path + ".part"
 
     # Must have at least the temp file or the final file
-    if not os.path.exists(temp_path) and not os.path.exists(final_path):
+    if not xbmcvfs.exists(temp_path) and not xbmcvfs.exists(final_path):
         notification("File not found.")
         return
 
     meta_path = final_path + ".jacktook.json"
     try:
-        with open(meta_path, "r") as f:
+        with open_file(meta_path, "r") as f:
             meta = json.load(f)
     except Exception as e:
         kodilog(f"[Downloader] Failed to read metadata for resume: {str(e)}")
@@ -503,8 +506,8 @@ def get_download_metadata(path):
     meta_path = final_path + ".jacktook.json"
     defaults = {"status": "unknown", "progress": 0, "title": ""}
     try:
-        if os.path.exists(meta_path):
-            with open(meta_path, "r") as f:
+        if xbmcvfs.exists(meta_path):
+            with open_file(meta_path, "r") as f:
                 meta = json.load(f)
             defaults.update(meta)
     except Exception:
@@ -539,19 +542,29 @@ def _count_active_downloads(directory):
     across all subdirectories."""
     count = 0
     try:
-        for root, dirs, files in os.walk(directory):
-            for f in files:
-                if f.endswith(".jacktook.json"):
-                    # Derive the actual download path from the metadata file
-                    download_path = os.path.join(root, f.replace(".jacktook.json", ""))
-                    if download_path.endswith(".part"):
-                        download_path = download_path[:-5]
-                    meta = get_download_metadata(download_path)
-                    status = meta.get("status", "")
-                    if status in ("downloading", "paused"):
-                        count += 1
+        count = _walk_count_active(directory)
     except Exception:
         pass
+    return count
+
+
+def _walk_count_active(directory):
+    """Recursively walk a directory using xbmcvfs and count active downloads."""
+    count = 0
+    dirs, files = xbmcvfs.listdir(directory)
+    for f in files:
+        f = f.decode("utf-8") if isinstance(f, bytes) else f
+        if f.endswith(".jacktook.json"):
+            download_path = os.path.join(directory, f.replace(".jacktook.json", ""))
+            if download_path.endswith(".part"):
+                download_path = download_path[:-5]
+            meta = get_download_metadata(download_path)
+            status = meta.get("status", "")
+            if status in ("downloading", "paused"):
+                count += 1
+    for d in dirs:
+        d = d.decode("utf-8") if isinstance(d, bytes) else d
+        count += _walk_count_active(os.path.join(directory, d))
     return count
 
 

--- a/lib/downloader.py
+++ b/lib/downloader.py
@@ -41,22 +41,25 @@ cancel_flag_cache = MemoryCache()
 def handle_download_file(params):
     destination = params.get("destination")
     if not destination or not os.path.exists(destination):
+        kodilog(f"[Downloader] Invalid download destination: {destination}")
         notification("Invalid download destination.")
         return
 
-    file_name = normalize_file_name(params.get("file_name", ""), params.get("url", ""))
+    url = params.get("url", "")
+    file_name = normalize_file_name(params.get("file_name", ""), url)
     dest_path = os.path.join(destination, file_name)
     cancel_key = dest_path
-    kodilog(f"Setting cancel event cache key: {cancel_key}")
+    kodilog(f"[Downloader] handle_download_file: file_name={file_name}, dest_path={dest_path}, url_length={len(url)}")
 
     manager = DownloadManager()
-    entry = manager.register(name=file_name, dest_path=dest_path, url=params.get("url", ""))
+    entry = manager.register(name=file_name, dest_path=dest_path, url=url)
     if entry is None:
+        kodilog(f"[Downloader] Download already in progress: {dest_path}")
         notification("Download already in progress.")
         return
 
     downloader = Downloader(
-        url=params.get("url"),
+        url=url,
         destination=destination,
         name=file_name,
         registry_id=dest_path,
@@ -65,6 +68,9 @@ def handle_download_file(params):
     thread = downloader.run()
     if thread:
         manager.set_thread(dest_path, thread)
+        kodilog(f"[Downloader] Download thread started for: {dest_path}")
+    else:
+        kodilog(f"[Downloader] Failed to start download thread for: {dest_path}")
 
 
 def download_cloud_file(params):

--- a/lib/downloader.py
+++ b/lib/downloader.py
@@ -152,7 +152,7 @@ def download_video(params):
 
 
 class ProgressHandler:
-    def update(self, percent: int, message: str):
+    def update(self, percent: int, message: str, downloaded_str: str = "", size_str: str = "", speed_str: str = "", eta_str: str = ""):
         pass
 
     def cancelled(self) -> bool:
@@ -167,8 +167,8 @@ class KodiProgressHandler(ProgressHandler):
         self.dialog = CustomProgressDialog("custom_progress_dialog.xml", addon_path)
         self.dialog.show_dialog()
 
-    def update(self, percent: int, message: str):
-        self.dialog.update_progress(percent, message)
+    def update(self, percent: int, message: str, downloaded_str: str = "", size_str: str = "", speed_str: str = "", eta_str: str = ""):
+        self.dialog.update_progress(percent, message, downloaded_str, size_str, speed_str, eta_str)
 
     def cancelled(self) -> bool:
         return self.dialog.cancelled
@@ -266,9 +266,17 @@ class Downloader:
         return thread
 
     def _run(self):
+        # Show progress dialog immediately, before network calls
+        if self.show_progress:
+            self.progress_handler = KodiProgressHandler("Downloading", ADDON_PATH)
+            self.progress_handler.update(0, translation(90807))
+        else:
+            self.progress_handler = ProgressHandler()
+
         self._prepare_url()
         if not self._validate_url():
             notification("Invalid URL for download.")
+            self.progress_handler.close()
             return
         self._start_download()
 
@@ -303,10 +311,13 @@ class Downloader:
         downloaded = 0
         file_mode = "wb"
 
-        if self.show_progress:
-            self.progress_handler = KodiProgressHandler("Downloading", ADDON_PATH)
-        else:
-            self.progress_handler = ProgressHandler()
+        # Ensure progress handler exists (may already be set by _run)
+        if self.progress_handler is None:
+            if self.show_progress:
+                self.progress_handler = KodiProgressHandler("Downloading", ADDON_PATH)
+            else:
+                self.progress_handler = ProgressHandler()
+
         self._write_metadata("downloading", 0)
         self._set_registry_status("downloading")
         self._start_time = time.time()
@@ -357,9 +368,35 @@ class Downloader:
                     else:
                         percent = 0
 
+                    # Calculate speed and ETA for progress display
+                    speed_str = ""
+                    eta_str = ""
+                    if self._start_time is not None:
+                        elapsed = time.time() - self._start_time
+                        if elapsed > 0:
+                            speed = int(downloaded / elapsed)
+                            speed_str = f"{bytes_to_human_readable(speed)}/s"
+                            remaining = self.file_size - downloaded
+                            if speed > 0 and remaining > 0:
+                                eta_secs = int(remaining / speed)
+                                eta_mins, eta_secs = divmod(eta_secs, 60)
+                                eta_hrs, eta_mins = divmod(eta_mins, 60)
+                                if eta_hrs:
+                                    eta_str = f"{eta_hrs}h {eta_mins}m"
+                                elif eta_mins:
+                                    eta_str = f"{eta_mins}m {eta_secs}s"
+                                else:
+                                    eta_str = f"{eta_secs}s"
+                            else:
+                                eta_str = ""
+
                     self.progress_handler.update(
                         percent,
-                        f"{self.name} - {percent}% - {bytes_to_human_readable(downloaded)} / {bytes_to_human_readable(self.file_size)}",
+                        self.name,
+                        f"{bytes_to_human_readable(downloaded)} / {bytes_to_human_readable(self.file_size)}",
+                        f"{percent}%",
+                        speed_str,
+                        eta_str,
                     )
                     self._write_metadata("downloading", percent)
                     self._update_registry(downloaded, percent)
@@ -392,7 +429,8 @@ class Downloader:
             self._set_registry_status("error")
             notification(f"Download error: {str(e)}")
         finally:
-            self.progress_handler.close()
+            if self.progress_handler:
+                self.progress_handler.close()
 
 
 def handle_cancel_download(params):

--- a/lib/downloader.py
+++ b/lib/downloader.py
@@ -534,6 +534,27 @@ def handle_delete_file(params):
         notification(f"Failed to delete file: {str(e)}")
 
 
+def _count_active_downloads(directory):
+    """Count downloads that are in-progress (downloading or paused) recursively
+    across all subdirectories."""
+    count = 0
+    try:
+        for root, dirs, files in os.walk(directory):
+            for f in files:
+                if f.endswith(".jacktook.json"):
+                    # Derive the actual download path from the metadata file
+                    download_path = os.path.join(root, f.replace(".jacktook.json", ""))
+                    if download_path.endswith(".part"):
+                        download_path = download_path[:-5]
+                    meta = get_download_metadata(download_path)
+                    status = meta.get("status", "")
+                    if status in ("downloading", "paused"):
+                        count += 1
+    except Exception:
+        pass
+    return count
+
+
 def downloads_viewer(params):
     set_pluging_category(translation(90015))
     download_dir = translatePath(get_setting("download_dir"))
@@ -546,12 +567,18 @@ def downloads_viewer(params):
     try:
         setContent(ADDON_HANDLE, "files")
         directories, files = xbmcvfs.listdir(translated_path)
-        active_downloads = [
-            f for f in files if is_active_download(os.path.join(translated_path, f))
-        ]
+        # At root level, count active downloads recursively across all subfolders
+        is_root = translated_path.rstrip(os.sep) == download_dir.rstrip(os.sep)
+        if is_root:
+            active_count = _count_active_downloads(translated_path)
+        else:
+            active_downloads = [
+                f for f in files if is_active_download(os.path.join(translated_path, f))
+            ]
+            active_count = len(active_downloads)
 
         active_label = (
-            f"[COLOR red]{translation(90373)}: {len(active_downloads)}[/COLOR]"
+            f"[COLOR red]{translation(90373)}: {active_count}[/COLOR]"
         )
         active_item = xbmcgui.ListItem(label=active_label)
         active_item.setProperty("IsPlayable", "false")

--- a/lib/downloader.py
+++ b/lib/downloader.py
@@ -3,6 +3,7 @@ import os
 import ssl
 import threading
 import re
+import time
 from urllib.request import Request, urlopen
 from urllib.parse import parse_qsl, unquote, urlparse
 from lib.utils.general.utils import set_pluging_category, supported_video_extensions
@@ -10,6 +11,7 @@ from lib.utils.kodi.utils import (
     ADDON_HANDLE,
     apply_section_view,
     action_url_run,
+    build_url,
     bytes_to_human_readable,
     get_setting,
     kodilog,
@@ -20,7 +22,9 @@ from lib.utils.kodi.utils import (
     translation,
 )
 from lib.db.cached import MemoryCache
+from lib.download_manager import DownloadManager
 from lib.gui.custom_progress import CustomProgressDialog
+from lib.nav.debrid import resolve_cloud_download_url
 
 from xbmcplugin import (
     addDirectoryItems,
@@ -51,6 +55,49 @@ def handle_download_file(params):
     )
     cancel_flag_cache.set(cancel_key, downloader.is_cancelled)
     downloader.run()
+
+
+def download_cloud_file(params):
+    url = params.get("url", "")
+    filename = params.get("filename", "")
+    mode = params.get("mode", "movie")
+    debrid_type = params.get("debrid_type", "")
+
+    if not url and debrid_type == "TB":
+        url = resolve_cloud_download_url({
+            "debrid_type": debrid_type,
+            "torrent_id": params.get("torrent_id", ""),
+            "file_id": params.get("file_id", ""),
+        })
+
+    if not url:
+        notification("Download link unavailable.")
+        return
+
+    dest_data = {"title": filename, "mode": "movies" if mode in ("movie", "movies") else mode}
+    destination = get_destination_path(dest_data)
+    if not destination or not os.path.exists(destination):
+        notification("Invalid download destination.")
+        return
+
+    file_name = normalize_file_name(filename, url)
+    dest_path = os.path.join(destination, file_name)
+
+    manager = DownloadManager()
+    entry = manager.register(name=file_name, dest_path=dest_path, url=url)
+    if entry is None:
+        notification("Download already in progress.")
+        return
+
+    downloader = Downloader(
+        url=url,
+        destination=destination,
+        name=file_name,
+        registry_id=dest_path,
+    )
+    thread = downloader.run()
+    if thread:
+        manager.set_thread(dest_path, thread)
 
 
 def get_destination_path(data):
@@ -120,10 +167,14 @@ class Downloader:
         url: str,
         destination: str,
         name: str,
+        registry_id: str = None,
+        show_progress: bool = True,
     ):
         self.url = url
         self.destination = destination
         self.name = name
+        self.registry_id = registry_id
+        self.show_progress = show_progress
         self.headers = {}
         self.file_size = 0
         self.monitor = xbmc.Monitor()
@@ -132,26 +183,71 @@ class Downloader:
         self.dest_path = os.path.join(destination, name)
         self.temp_path = self.dest_path + ".part"
         self.meta_path = self.dest_path + ".jacktook.json"
+        self._start_time = None
 
-    def _write_metadata(self, status: str, progress: int = 0):
+    def _write_metadata(self, status: str, progress: int = 0, size: int = 0, downloaded: int = 0, speed: int = 0, eta: int = 0):
         try:
             meta = {
                 "title": self.name,
                 "url": self.url,
                 "status": status,
                 "progress": progress,
+                "size": size,
+                "downloaded": downloaded,
+                "speed": speed,
+                "eta": eta,
             }
             with open(self.meta_path, "w") as f:
                 json.dump(meta, f)
         except Exception as e:
             kodilog(f"[Downloader] Failed to write metadata: {str(e)}")
 
+    def _update_registry(self, downloaded: int, percent: int):
+        if not self.registry_id:
+            return
+        speed = 0
+        eta = 0
+        if self._start_time is not None:
+            elapsed = time.time() - self._start_time
+            if elapsed > 0:
+                speed = int(downloaded / elapsed)
+            remaining = self.file_size - downloaded
+            if speed > 0 and remaining > 0:
+                eta = int(remaining / speed)
+            else:
+                eta = 0
+        DownloadManager().update_progress(
+            self.registry_id,
+            downloaded=downloaded,
+            speed=speed,
+            eta=eta,
+            progress=percent,
+            size=self.file_size,
+        )
+
+    def _set_registry_status(self, status: str):
+        if not self.registry_id:
+            return
+        DownloadManager().set_status(self.registry_id, status)
+
+    def _is_cancelled(self):
+        if self.progress_handler and self.progress_handler.cancelled():
+            return True
+        if cancel_flag_cache.get(self.dest_path) is True:
+            return True
+        if self.registry_id:
+            entry = DownloadManager().get_entry(self.registry_id)
+            if entry and entry.cancel_flag:
+                return True
+        return False
+
     def run(self):
         if not self.url:
             notification("No URL provided for download.")
-            return
+            return None
         thread = threading.Thread(target=self._run, daemon=True)
         thread.start()
+        return thread
 
     def _run(self):
         self._prepare_url()
@@ -191,8 +287,13 @@ class Downloader:
         downloaded = 0
         file_mode = "wb"
 
-        self.progress_handler = KodiProgressHandler("Downloading", ADDON_PATH)
+        if self.show_progress:
+            self.progress_handler = KodiProgressHandler("Downloading", ADDON_PATH)
+        else:
+            self.progress_handler = ProgressHandler()
         self._write_metadata("downloading", 0)
+        self._set_registry_status("downloading")
+        self._start_time = time.time()
 
         try:
             # Resume support — check temp file
@@ -206,6 +307,7 @@ class Downloader:
                     if xbmcvfs.exists(self.temp_path):
                         xbmcvfs.rename(self.temp_path, self.dest_path)
                     self._write_metadata("completed", 100)
+                    self._set_registry_status("completed")
                     notification(f"File already downloaded: {self.name}")
                     return
 
@@ -214,6 +316,7 @@ class Downloader:
                 downloaded = os.path.getsize(self.dest_path)
                 if downloaded >= self.file_size:
                     self._write_metadata("completed", 100)
+                    self._set_registry_status("completed")
                     notification(f"File already downloaded: {self.name}")
                     return
 
@@ -243,15 +346,14 @@ class Downloader:
                         f"{self.name} - {percent}% - {bytes_to_human_readable(downloaded)} / {bytes_to_human_readable(self.file_size)}",
                     )
                     self._write_metadata("downloading", percent)
+                    self._update_registry(downloaded, percent)
 
                     # Handle cancellation
-                    if (
-                        self.progress_handler.cancelled()
-                        or cancel_flag_cache.get(self.dest_path) is True
-                    ):
+                    if self._is_cancelled():
                         cancel_flag_cache.set(self.dest_path, True)
                         self.is_cancelled = True
                         self._write_metadata("paused", percent)
+                        self._set_registry_status("paused")
                         file.close()
                         break
 
@@ -268,8 +370,10 @@ class Downloader:
                     if xbmcvfs.exists(self.temp_path):
                         xbmcvfs.rename(self.temp_path, self.dest_path)
                     self._write_metadata("completed", 100)
+                    self._set_registry_status("completed")
                     notification(f"Download completed: {self.name}")
         except Exception as e:
+            self._set_registry_status("error")
             notification(f"Download error: {str(e)}")
         finally:
             self.progress_handler.close()
@@ -284,7 +388,7 @@ def handle_cancel_download(params):
         notification("No active download found.")
 
 
-def handle_pause_download(params):
+def handle_pause_download(params, refresh=True):
     file_path = json.loads(params.get("file_path"))
     if file_path:
         # Derive final path (strip .part if present)
@@ -300,7 +404,8 @@ def handle_pause_download(params):
                     json.dump(meta, f)
         except Exception as e:
             kodilog(f"[Downloader] Failed to update pause metadata: {str(e)}")
-        xbmc.executebuiltin("Container.Refresh")
+        if refresh:
+            xbmc.executebuiltin("Container.Refresh")
     else:
         notification("No active download found.")
 
@@ -431,6 +536,15 @@ def downloads_viewer(params):
                 info_tag = list_item.getVideoInfoTag()
                 info_tag.setTitle(display_name)
                 info_tag.setMediaType("file")
+
+                # Make completed files playable directly via plugin URL
+                if status == "completed" and not item.endswith(".part"):
+                    play_url = build_url("play_url", url=item_path, name=display_name)
+                    list_item.setProperty("IsPlayable", "true")
+                    list_item.setPath(play_url)
+                else:
+                    list_item.setProperty("IsPlayable", "false")
+
                 context_menu = []
 
                 if status == "downloading":
@@ -476,7 +590,14 @@ def downloads_viewer(params):
 
                 list_item.addContextMenuItems(context_menu)
                 is_folder = False
-            item_list.append((item_path, list_item, is_folder))
+
+                # Use plugin URL for playable completed files so Kodi routes
+                # them through play_url for proper resolution
+                if status == "completed" and not item.endswith(".part"):
+                    listing_url = build_url("play_url", url=item_path, name=display_name)
+                else:
+                    listing_url = item_path
+            item_list.append((listing_url, list_item, is_folder))
 
         addDirectoryItems(ADDON_HANDLE, item_list)
         endOfDirectory(ADDON_HANDLE)

--- a/lib/downloader.py
+++ b/lib/downloader.py
@@ -79,7 +79,7 @@ def download_cloud_file(params):
     mode = params.get("mode", "movie")
     debrid_type = params.get("debrid_type", "")
 
-    if not url and debrid_type == "TB":
+    if not url and debrid_type in ("TB", "Torbox"):
         url = resolve_cloud_download_url({
             "debrid_type": debrid_type,
             "torrent_id": params.get("torrent_id", ""),
@@ -92,7 +92,7 @@ def download_cloud_file(params):
 
     dest_data = {"title": filename, "mode": "movies" if mode in ("movie", "movies") else mode}
     destination = get_destination_path(dest_data)
-    if not destination or not os.path.exists(destination):
+    if not destination:
         notification("Invalid download destination.")
         return
 
@@ -536,7 +536,11 @@ def handle_delete_file(params):
 
 def downloads_viewer(params):
     set_pluging_category(translation(90015))
-    translated_path = translatePath(get_setting("download_dir"))
+    download_dir = translatePath(get_setting("download_dir"))
+    path = params.get("path", download_dir)
+    if not path:
+        path = download_dir
+    translated_path = translatePath(path)
     item_list = []
 
     try:
@@ -570,6 +574,8 @@ def downloads_viewer(params):
                 info_tag.setMediaType("folder")
                 list_item.setProperty("IsPlayable", "false")
                 is_folder = True
+                # Navigate through the plugin so subdirectories work correctly
+                listing_url = build_url("downloads_viewer", path=item_path)
             else:
                 # Strip .part for display but keep it for internal path
                 display_name = item[:-5] if item.endswith(".part") else item

--- a/lib/downloader.py
+++ b/lib/downloader.py
@@ -45,16 +45,26 @@ def handle_download_file(params):
         return
 
     file_name = normalize_file_name(params.get("file_name", ""), params.get("url", ""))
-    cancel_key = os.path.join(destination, file_name)
+    dest_path = os.path.join(destination, file_name)
+    cancel_key = dest_path
     kodilog(f"Setting cancel event cache key: {cancel_key}")
+
+    manager = DownloadManager()
+    entry = manager.register(name=file_name, dest_path=dest_path, url=params.get("url", ""))
+    if entry is None:
+        notification("Download already in progress.")
+        return
 
     downloader = Downloader(
         url=params.get("url"),
         destination=destination,
         name=file_name,
+        registry_id=dest_path,
     )
     cancel_flag_cache.set(cancel_key, downloader.is_cancelled)
-    downloader.run()
+    thread = downloader.run()
+    if thread:
+        manager.set_thread(dest_path, thread)
 
 
 def download_cloud_file(params):

--- a/lib/gui/custom_progress.py
+++ b/lib/gui/custom_progress.py
@@ -21,13 +21,22 @@ class CustomProgressDialog(xbmcgui.WindowXMLDialog):
         self.getControl(12001).setLabel(self.title)
         self.getControl(12002).setLabel(self.message)
         self.getControl(12004).setPercent(self.progress)
+        self.getControl(12006).setLabel(f"{self.progress}%")
         self.setFocusId(12003)
 
-    def update_progress(self, percent, message=None):
+    def update_progress(self, percent, message=None, downloaded_str="", size_str="", speed_str="", eta_str=""):
         self.progress = percent
-        self.getControl(12004).setPercent(percent)
-        if message:
-            self.getControl(12002).setLabel(message)
+        try:
+            self.getControl(12004).setPercent(percent)
+            self.getControl(12006).setLabel(f"{percent}%")
+            if message:
+                self.getControl(12002).setLabel(message)
+            if downloaded_str:
+                self.getControl(12007).setLabel(downloaded_str)
+            if speed_str:
+                self.getControl(12008).setLabel(f"{speed_str}  |  {eta_str}")
+        except Exception as e:
+            kodilog(f"[CustomProgressDialog] Update error: {e}")
 
     def onClick(self, controlId):
         if controlId == 12003:  # Cancel button

--- a/lib/gui/download_manager_window.py
+++ b/lib/gui/download_manager_window.py
@@ -11,7 +11,7 @@ from lib.download_manager import DownloadManager
 from lib.downloader import Downloader, cancel_flag_cache, get_download_metadata, handle_pause_download, resume_download
 from lib.gui.base_window import BaseWindow
 from lib.utils.kodi.settings import get_setting as _get_setting
-from lib.utils.kodi.utils import ADDON_PATH, bytes_to_human_readable, execute_builtin, kodilog, translatePath as _translatePath, translation
+from lib.utils.kodi.utils import ADDON_PATH, bytes_to_human_readable, execute_builtin, kodilog, open_file as _open_file, translatePath as _translatePath, translation
 
 
 class DownloadManagerWindow(BaseWindow):
@@ -37,59 +37,69 @@ class DownloadManagerWindow(BaseWindow):
         that downloads started before the window was opened, or organized
         into subfolders, appear in the manager."""
         download_dir = _translatePath(_get_setting("download_dir"))
-        if not download_dir or not os.path.isdir(download_dir):
+        if not download_dir or not xbmcvfs.exists(download_dir):
+            kodilog(f"[DownloadManagerWindow] Download directory not found: {download_dir}")
             return
 
         manager = DownloadManager()
         try:
-            for root, dirs, files in os.walk(download_dir):
-                for filename in files:
-                    if not filename.endswith(".jacktook.json"):
-                        continue
-                    dest_path = os.path.join(root, filename.replace(".jacktook.json", ""))
-                    # Skip .part files — use the final path
-                    if dest_path.endswith(".part"):
-                        dest_path = dest_path[:-5]
-                    meta = get_download_metadata(dest_path)
-                    if not meta:
-                        continue
-                    status = meta.get("status", "unknown")
-                    progress = meta.get("progress", 0)
-                    url = meta.get("url", "")
-                    name = meta.get("title", os.path.basename(dest_path))
-                    # Only register non-cancelled entries
-                    if status == "cancelled":
-                        continue
-                    entry = manager.get_entry(dest_path)
-                    if entry:
-                        # Update existing entry from disk
-                        manager.set_status(dest_path, status)
-                        manager.update_progress(
-                            dest_path,
-                            downloaded=meta.get("downloaded", 0),
-                            speed=meta.get("speed", 0),
-                            eta=meta.get("eta", 0),
-                            progress=progress,
-                            size=meta.get("size", 0),
-                        )
-                    else:
-                        entry = manager.register(
-                            name=name,
-                            dest_path=dest_path,
-                            url=url,
-                        )
-                        if entry:
-                            manager.set_status(dest_path, status)
-                            manager.update_progress(
-                                dest_path,
-                                downloaded=meta.get("downloaded", 0),
-                                speed=meta.get("speed", 0),
-                                eta=meta.get("eta", 0),
-                                progress=progress,
-                                size=meta.get("size", 0),
-                            )
+            self._walk_and_sync(download_dir, manager)
         except Exception as e:
             kodilog(f"[DownloadManagerWindow] Sync from disk error: {e}")
+
+    def _walk_and_sync(self, directory, manager):
+        """Recursively walk a directory using xbmcvfs and sync .jacktook.json files."""
+        dirs, files = xbmcvfs.listdir(directory)
+        for filename in files:
+            filename = filename.decode("utf-8") if isinstance(filename, bytes) else filename
+            if not filename.endswith(".jacktook.json"):
+                continue
+            dest_path = os.path.join(directory, filename.replace(".jacktook.json", ""))
+            # Skip .part files — use the final path
+            if dest_path.endswith(".part"):
+                dest_path = dest_path[:-5]
+            meta = get_download_metadata(dest_path)
+            if not meta:
+                continue
+            status = meta.get("status", "unknown")
+            progress = meta.get("progress", 0)
+            url = meta.get("url", "")
+            name = meta.get("title", os.path.basename(dest_path))
+            # Only register non-cancelled entries
+            if status == "cancelled":
+                continue
+            entry = manager.get_entry(dest_path)
+            if entry:
+                # Update existing entry from disk
+                manager.set_status(dest_path, status)
+                manager.update_progress(
+                    dest_path,
+                    downloaded=meta.get("downloaded", 0),
+                    speed=meta.get("speed", 0),
+                    eta=meta.get("eta", 0),
+                    progress=progress,
+                    size=meta.get("size", 0),
+                )
+            else:
+                entry = manager.register(
+                    name=name,
+                    dest_path=dest_path,
+                    url=url,
+                )
+                if entry:
+                    manager.set_status(dest_path, status)
+                    manager.update_progress(
+                        dest_path,
+                        downloaded=meta.get("downloaded", 0),
+                        speed=meta.get("speed", 0),
+                        eta=meta.get("eta", 0),
+                        progress=progress,
+                        size=meta.get("size", 0),
+                    )
+        for dirname in dirs:
+            dirname = dirname.decode("utf-8") if isinstance(dirname, bytes) else dirname
+            subdir = os.path.join(directory, dirname)
+            self._walk_and_sync(subdir, manager)
 
     def _poll_loop(self):
         last_sync = 0
@@ -322,12 +332,12 @@ class DownloadManagerWindow(BaseWindow):
 
         # Update metadata on disk so a cancelled download doesn't resume on restart
         meta_path = entry_id + ".jacktook.json"
-        if os.path.exists(meta_path):
+        if xbmcvfs.exists(meta_path):
             try:
-                with open(meta_path, "r") as f:
+                with _open_file(meta_path, "r") as f:
                     meta = json.load(f)
                 meta["status"] = "cancelled"
-                with open(meta_path, "w") as f:
+                with _open_file(meta_path, "w") as f:
                     json.dump(meta, f)
             except Exception:
                 pass

--- a/lib/gui/download_manager_window.py
+++ b/lib/gui/download_manager_window.py
@@ -1,3 +1,4 @@
+import json
 import os
 import threading
 import time
@@ -167,12 +168,47 @@ class DownloadManagerWindow(BaseWindow):
 
             self.setProperty("downloads_empty", "false")
             for entry in entries:
-                label = f"{entry.name} [{entry.progress}%]"
+                label = entry.name
+                speed_str = bytes_to_human_readable(entry.speed) + "/s" if entry.speed else ""
+                if entry.eta and entry.eta > 0:
+                    eta_mins, eta_secs = divmod(entry.eta, 60)
+                    eta_hrs, eta_mins = divmod(eta_mins, 60)
+                    if eta_hrs:
+                        eta_str = f"{eta_hrs}h {eta_mins}m"
+                    elif eta_mins:
+                        eta_str = f"{eta_mins}m {eta_secs}s"
+                    else:
+                        eta_str = f"{eta_secs}s"
+                else:
+                    eta_str = ""
+                size_str = bytes_to_human_readable(entry.size) if entry.size else ""
+                downloaded_str = bytes_to_human_readable(entry.downloaded) if entry.downloaded else ""
+
+                # Build secondary info line
+                parts = []
+                if entry.status == "completed":
+                    status_str = translation(90811)  # "Completed"
+                elif speed_str:
+                    parts.append(speed_str)
+                if eta_str and entry.status != "completed":
+                    parts.append(eta_str)
+                if downloaded_str and size_str:
+                    parts.append(f"{downloaded_str} / {size_str}")
+                elif size_str:
+                    parts.append(size_str)
+
+                info_line = " • ".join(parts)
+
                 item = xbmcgui.ListItem(label=label)
                 item.setProperty("entry_id", entry.id)
                 item.setProperty("entry_name", entry.name)
                 item.setProperty("entry_status", entry.status)
                 item.setProperty("entry_progress", str(entry.progress))
+                item.setProperty("entry_speed", speed_str)
+                item.setProperty("entry_eta", eta_str)
+                item.setProperty("entry_size", size_str)
+                item.setProperty("entry_downloaded", downloaded_str)
+                item.setProperty("entry_info", info_line)
                 control_list.addItem(item)
 
             if 0 <= selected_position < control_list.size():
@@ -276,9 +312,30 @@ class DownloadManagerWindow(BaseWindow):
     def _cancel_download(self, entry_id):
         manager = DownloadManager()
         entry = manager.get_entry(entry_id)
-        if entry and entry.status == "downloading":
-            entry.cancel_flag = True
-            manager.set_status(entry_id, "cancelled")
+        if not entry:
+            return
+
+        # Cancel works for both downloading and paused states
+        entry.cancel_flag = True
+        cancel_flag_cache.set(entry_id, True)
+        manager.set_status(entry_id, "cancelled")
+
+        # Update metadata on disk so a cancelled download doesn't resume on restart
+        meta_path = entry_id + ".jacktook.json"
+        if os.path.exists(meta_path):
+            try:
+                with open(meta_path, "r") as f:
+                    meta = json.load(f)
+                meta["status"] = "cancelled"
+                with open(meta_path, "w") as f:
+                    json.dump(meta, f)
+            except Exception:
+                pass
+
+        # Delete the .part file (partial download) to free disk space
+        temp_path = entry_id + ".part"
+        if xbmcvfs.exists(temp_path):
+            xbmcvfs.delete(temp_path)
 
     def _delete_download(self, entry_id):
         manager = DownloadManager()

--- a/lib/gui/download_manager_window.py
+++ b/lib/gui/download_manager_window.py
@@ -1,0 +1,285 @@
+import os
+import threading
+
+import xbmc
+import xbmcgui
+import xbmcvfs
+
+from lib.download_manager import DownloadManager
+from lib.downloader import Downloader, cancel_flag_cache, get_download_metadata, handle_pause_download, resume_download
+from lib.gui.base_window import BaseWindow
+from lib.utils.kodi.settings import get_setting as _get_setting
+from lib.utils.kodi.utils import ADDON_PATH, bytes_to_human_readable, execute_builtin, kodilog, translatePath as _translatePath
+
+
+class DownloadManagerWindow(BaseWindow):
+    def __init__(self, xml_file, location, item_information=None, previous_window=None):
+        super().__init__(xml_file, location, item_information, previous_window)
+        self._monitor = xbmc.Monitor()
+        self._closed = False
+        self._poll_thread = None
+        self._focused_item_id = None
+        self._last_registry_checksum = ""
+
+    def onInit(self):
+        self.setProperty("instant_close", "false")
+        self._sync_from_disk()
+        self._rebuild_list()
+        self._poll_thread = threading.Thread(target=self._poll_loop)
+        self._poll_thread.daemon = True
+        self._poll_thread.start()
+
+    def _sync_from_disk(self):
+        """Scan the download directory for .jacktook.json files and register
+        any downloads that are not already in the registry. This ensures
+        that downloads started before the window was opened (or before
+        Kodi was restarted) appear in the manager."""
+        download_dir = _translatePath(_get_setting("download_dir"))
+        if not download_dir or not os.path.isdir(download_dir):
+            return
+
+        manager = DownloadManager()
+        try:
+            for filename in os.listdir(download_dir):
+                if not filename.endswith(".jacktook.json"):
+                    continue
+                dest_path = os.path.join(download_dir, filename.replace(".jacktook.json", ""))
+                # Skip .part files — use the final path
+                if dest_path.endswith(".part"):
+                    dest_path = dest_path[:-5]
+                if manager.get_entry(dest_path):
+                    continue
+                meta = get_download_metadata(dest_path)
+                if not meta:
+                    continue
+                status = meta.get("status", "unknown")
+                progress = meta.get("progress", 0)
+                url = meta.get("url", "")
+                name = meta.get("title", os.path.basename(dest_path))
+                # Only register non-cancelled entries
+                if status == "cancelled":
+                    continue
+                entry = manager.register(
+                    name=name,
+                    dest_path=dest_path,
+                    url=url,
+                )
+                if entry:
+                    manager.set_status(dest_path, status)
+                    manager.update_progress(
+                        dest_path,
+                        downloaded=0,
+                        speed=0,
+                        eta=0,
+                        progress=progress,
+                        size=0,
+                    )
+        except Exception as e:
+            kodilog(f"[DownloadManagerWindow] Sync from disk error: {e}")
+
+    def _poll_loop(self):
+        while not self._monitor.abortRequested() and not self._closed:
+            xbmc.sleep(500)
+            try:
+                self._update_selected_properties()
+                self._check_registry_changes()
+            except Exception as e:
+                kodilog(f"[DownloadManagerWindow] Poll error: {e}")
+
+    def _update_selected_properties(self):
+        # Always sync focused_item_id from the list's current selection
+        # so the details panel reflects keyboard/gamepad navigation too
+        try:
+            control_list = self.getControl(14001)
+            item = control_list.getSelectedItem()
+            if item:
+                self._focused_item_id = item.getProperty("entry_id") or self._focused_item_id
+        except Exception:
+            pass
+
+        manager = DownloadManager()
+        entry = manager.get_entry(self._focused_item_id) if self._focused_item_id else None
+        if entry:
+            self.setProperty("selected_progress", str(entry.progress))
+            self.setProperty("selected_speed", bytes_to_human_readable(entry.speed) + "/s" if entry.speed else "")
+            eta_secs = entry.eta
+            if eta_secs and eta_secs > 0:
+                eta_mins, eta_secs = divmod(eta_secs, 60)
+                eta_hrs, eta_mins = divmod(eta_mins, 60)
+                if eta_hrs:
+                    self.setProperty("selected_eta", f"{eta_hrs}h {eta_mins}m")
+                elif eta_mins:
+                    self.setProperty("selected_eta", f"{eta_mins}m {eta_secs}s")
+                else:
+                    self.setProperty("selected_eta", f"{eta_secs}s")
+            else:
+                self.setProperty("selected_eta", "")
+            self.setProperty("selected_size", bytes_to_human_readable(entry.size) if entry.size else "")
+            self.setProperty("selected_downloaded", bytes_to_human_readable(entry.downloaded) if entry.downloaded else "")
+            self.setProperty("selected_status", entry.status)
+            self.setProperty("selected_name", entry.name)
+        else:
+            self.setProperty("selected_progress", "")
+            self.setProperty("selected_speed", "")
+            self.setProperty("selected_eta", "")
+            self.setProperty("selected_size", "")
+            self.setProperty("selected_downloaded", "")
+            self.setProperty("selected_status", "")
+            self.setProperty("selected_name", "")
+
+    def _check_registry_changes(self):
+        manager = DownloadManager()
+        entries = manager.list_entries()
+        checksum = ",".join(f"{e.id}:{e.status}:{e.progress}" for e in entries)
+        if checksum != self._last_registry_checksum:
+            self._last_registry_checksum = checksum
+            execute_builtin("SendClick(14000,14002)")
+
+    def _rebuild_list(self):
+        try:
+            manager = DownloadManager()
+            entries = manager.list_entries()
+            control_list = self.getControl(14001)
+            selected_position = control_list.getSelectedPosition()
+            control_list.reset()
+
+            if not entries:
+                self.setProperty("downloads_empty", "true")
+                return
+
+            self.setProperty("downloads_empty", "false")
+            for entry in entries:
+                label = f"{entry.name} [{entry.progress}%]"
+                item = xbmcgui.ListItem(label=label)
+                item.setProperty("entry_id", entry.id)
+                item.setProperty("entry_name", entry.name)
+                item.setProperty("entry_status", entry.status)
+                item.setProperty("entry_progress", str(entry.progress))
+                control_list.addItem(item)
+
+            if 0 <= selected_position < control_list.size():
+                control_list.selectItem(selected_position)
+
+            # Set focus on the list so navigation works immediately
+            self.setFocus(control_list)
+
+            # Default focus to first entry if no previous selection
+            if self._focused_item_id is None and entries:
+                self._focused_item_id = entries[0].id
+        except Exception as e:
+            kodilog(f"[DownloadManagerWindow] Rebuild list error: {e}")
+
+    def onAction(self, action):
+        action_id = action.getId()
+        if action_id in self.action_exitkeys_id:
+            self._closed = True
+        super().onAction(action)
+
+    def onClick(self, control_id):
+        if control_id == 14002:
+            self._rebuild_list()
+            return
+
+        if control_id == 14007:
+            self._clear_completed()
+            execute_builtin("SendClick(14000,14002)")
+            return
+
+        if control_id not in (14003, 14004, 14005, 14006):
+            return
+
+        try:
+            control_list = self.getControl(14001)
+            item = control_list.getSelectedItem()
+            if not item:
+                return
+            entry_id = item.getProperty("entry_id")
+            if not entry_id:
+                return
+        except Exception:
+            return
+
+        self._focused_item_id = entry_id
+
+        if control_id == 14003:
+            self._pause_download(entry_id)
+        elif control_id == 14004:
+            self._resume_download(entry_id)
+        elif control_id == 14005:
+            self._cancel_download(entry_id)
+        elif control_id == 14006:
+            self._delete_download(entry_id)
+
+        execute_builtin("SendClick(14000,14002)")
+
+    def _pause_download(self, entry_id):
+        manager = DownloadManager()
+        entry = manager.get_entry(entry_id)
+        if entry and entry.status == "downloading":
+            entry.cancel_flag = True
+            manager.set_status(entry_id, "paused")
+            import json
+            handle_pause_download({"file_path": json.dumps(entry_id)}, refresh=False)
+
+    def _resume_download(self, entry_id):
+        manager = DownloadManager()
+        entry = manager.get_entry(entry_id)
+        if entry and entry.status == "paused":
+            import json
+            import os
+            dest_path = entry_id
+            # Clear the cancel flag left by the pause operation
+            cancel_flag_cache.set(dest_path, False)
+            entry.cancel_flag = False
+            meta = get_download_metadata(dest_path)
+            manager.set_status(entry_id, "downloading")
+            manager.update_progress(
+                entry_id,
+                downloaded=meta.get("downloaded", 0),
+                speed=0,
+                eta=0,
+                progress=meta.get("progress", 0),
+                size=meta.get("size", 0),
+            )
+            downloader = Downloader(
+                url=meta.get("url", entry.url),
+                destination=os.path.dirname(dest_path),
+                name=os.path.basename(dest_path),
+                registry_id=dest_path,
+                show_progress=False,
+            )
+            downloader.run()
+
+    def _cancel_download(self, entry_id):
+        manager = DownloadManager()
+        entry = manager.get_entry(entry_id)
+        if entry and entry.status == "downloading":
+            entry.cancel_flag = True
+            manager.set_status(entry_id, "cancelled")
+
+    def _delete_download(self, entry_id):
+        manager = DownloadManager()
+        entry = manager.get_entry(entry_id)
+        if not entry:
+            return
+
+        # Delete files
+        if xbmcvfs.exists(entry_id):
+            xbmcvfs.delete(entry_id)
+        temp_path = entry_id + ".part"
+        if xbmcvfs.exists(temp_path):
+            xbmcvfs.delete(temp_path)
+        meta_path = entry_id + ".jacktook.json"
+        if xbmcvfs.exists(meta_path):
+            xbmcvfs.delete(meta_path)
+
+        manager.remove_entry(entry_id)
+
+    def _clear_completed(self):
+        manager = DownloadManager()
+        for entry in list(manager.list_entries()):
+            if entry.status == "completed":
+                manager.remove_entry(entry.id)
+
+    def handle_action(self, action_id, control_id=None):
+        pass

--- a/lib/gui/download_manager_window.py
+++ b/lib/gui/download_manager_window.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import time
 
 import xbmc
 import xbmcgui
@@ -9,7 +10,7 @@ from lib.download_manager import DownloadManager
 from lib.downloader import Downloader, cancel_flag_cache, get_download_metadata, handle_pause_download, resume_download
 from lib.gui.base_window import BaseWindow
 from lib.utils.kodi.settings import get_setting as _get_setting
-from lib.utils.kodi.utils import ADDON_PATH, bytes_to_human_readable, execute_builtin, kodilog, translatePath as _translatePath
+from lib.utils.kodi.utils import ADDON_PATH, bytes_to_human_readable, execute_builtin, kodilog, translatePath as _translatePath, translation
 
 
 class DownloadManagerWindow(BaseWindow):
@@ -30,57 +31,74 @@ class DownloadManagerWindow(BaseWindow):
         self._poll_thread.start()
 
     def _sync_from_disk(self):
-        """Scan the download directory for .jacktook.json files and register
-        any downloads that are not already in the registry. This ensures
-        that downloads started before the window was opened (or before
-        Kodi was restarted) appear in the manager."""
+        """Scan the download directory (recursively) for .jacktook.json files
+        and register or update any downloads in the registry. This ensures
+        that downloads started before the window was opened, or organized
+        into subfolders, appear in the manager."""
         download_dir = _translatePath(_get_setting("download_dir"))
         if not download_dir or not os.path.isdir(download_dir):
             return
 
         manager = DownloadManager()
         try:
-            for filename in os.listdir(download_dir):
-                if not filename.endswith(".jacktook.json"):
-                    continue
-                dest_path = os.path.join(download_dir, filename.replace(".jacktook.json", ""))
-                # Skip .part files — use the final path
-                if dest_path.endswith(".part"):
-                    dest_path = dest_path[:-5]
-                if manager.get_entry(dest_path):
-                    continue
-                meta = get_download_metadata(dest_path)
-                if not meta:
-                    continue
-                status = meta.get("status", "unknown")
-                progress = meta.get("progress", 0)
-                url = meta.get("url", "")
-                name = meta.get("title", os.path.basename(dest_path))
-                # Only register non-cancelled entries
-                if status == "cancelled":
-                    continue
-                entry = manager.register(
-                    name=name,
-                    dest_path=dest_path,
-                    url=url,
-                )
-                if entry:
-                    manager.set_status(dest_path, status)
-                    manager.update_progress(
-                        dest_path,
-                        downloaded=0,
-                        speed=0,
-                        eta=0,
-                        progress=progress,
-                        size=0,
-                    )
+            for root, dirs, files in os.walk(download_dir):
+                for filename in files:
+                    if not filename.endswith(".jacktook.json"):
+                        continue
+                    dest_path = os.path.join(root, filename.replace(".jacktook.json", ""))
+                    # Skip .part files — use the final path
+                    if dest_path.endswith(".part"):
+                        dest_path = dest_path[:-5]
+                    meta = get_download_metadata(dest_path)
+                    if not meta:
+                        continue
+                    status = meta.get("status", "unknown")
+                    progress = meta.get("progress", 0)
+                    url = meta.get("url", "")
+                    name = meta.get("title", os.path.basename(dest_path))
+                    # Only register non-cancelled entries
+                    if status == "cancelled":
+                        continue
+                    entry = manager.get_entry(dest_path)
+                    if entry:
+                        # Update existing entry from disk
+                        manager.set_status(dest_path, status)
+                        manager.update_progress(
+                            dest_path,
+                            downloaded=meta.get("downloaded", 0),
+                            speed=meta.get("speed", 0),
+                            eta=meta.get("eta", 0),
+                            progress=progress,
+                            size=meta.get("size", 0),
+                        )
+                    else:
+                        entry = manager.register(
+                            name=name,
+                            dest_path=dest_path,
+                            url=url,
+                        )
+                        if entry:
+                            manager.set_status(dest_path, status)
+                            manager.update_progress(
+                                dest_path,
+                                downloaded=meta.get("downloaded", 0),
+                                speed=meta.get("speed", 0),
+                                eta=meta.get("eta", 0),
+                                progress=progress,
+                                size=meta.get("size", 0),
+                            )
         except Exception as e:
             kodilog(f"[DownloadManagerWindow] Sync from disk error: {e}")
 
     def _poll_loop(self):
+        last_sync = 0
         while not self._monitor.abortRequested() and not self._closed:
             xbmc.sleep(500)
             try:
+                now = time.time()
+                if now - last_sync >= 2:
+                    self._sync_from_disk()
+                    last_sync = now
                 self._update_selected_properties()
                 self._check_registry_changes()
             except Exception as e:
@@ -266,6 +284,10 @@ class DownloadManagerWindow(BaseWindow):
         manager = DownloadManager()
         entry = manager.get_entry(entry_id)
         if not entry:
+            return
+
+        dialog = xbmcgui.Dialog()
+        if not dialog.yesno(translation(90809), translation(90810)):
             return
 
         # Delete files

--- a/lib/gui/download_manager_window.py
+++ b/lib/gui/download_manager_window.py
@@ -180,6 +180,11 @@ class DownloadManagerWindow(BaseWindow):
             self._rebuild_list()
             return
 
+        if control_id == 14008:
+            self._closed = True
+            self.close()
+            return
+
         if control_id == 14007:
             self._clear_completed()
             execute_builtin("SendClick(14000,14002)")

--- a/lib/gui/source_select.py
+++ b/lib/gui/source_select.py
@@ -449,7 +449,6 @@ class SourceSelect(BaseWindow):
             notification(translation(90407))
             return
 
-        download_dir = get_setting("download_dir")
         try:
             title = (self.playback_info.get("title") or self.item_information.get("title") or "").strip()
             year = self.item_information.get("year", "")
@@ -466,12 +465,23 @@ class SourceSelect(BaseWindow):
             else:
                 file_name = title
 
+            mode = self.playback_info.get("mode", "movie")
+            dest_data = {"title": title, "mode": "movies" if mode in ("movie", "movies") else mode}
+            if tv_data:
+                dest_data["tv_data"] = tv_data
+
+            from lib.downloader import get_destination_path
+            destination = get_destination_path(dest_data)
+            if not destination:
+                notification(translation(90407))
+                return
+
             xbmc.executebuiltin(
                 action_url_run(
                     "handle_download_file",
                     file_name=file_name,
                     url=self.playback_info["url"],
-                    destination=translatePath(download_dir),
+                    destination=destination,
                 )
             )
         except Exception as e:

--- a/lib/nav/debrid.py
+++ b/lib/nav/debrid.py
@@ -326,10 +326,10 @@ def download(magnet, debrid_type):
 
 def resolve_cloud_download_url(data):
     debrid_type = data.get("debrid_type", "")
-    if debrid_type == "RD":
+    if debrid_type in ("RD", "RealDebrid"):
         url = data.get("url", "")
         return url if url else None
-    elif debrid_type == "TB":
+    elif debrid_type in ("TB", "Torbox"):
         torrent_id = data.get("torrent_id", "")
         file_id = data.get("file_id", "")
         if not torrent_id or not file_id:

--- a/lib/nav/debrid.py
+++ b/lib/nav/debrid.py
@@ -27,6 +27,7 @@ from lib.utils.general.utils import (
     IndexerType,
     build_list_item,
     check_debrid_enabled,
+    get_public_ip,
     get_random_color,
     set_pluging_category,
 )
@@ -199,16 +200,31 @@ def get_rd_downloads(params):
         downloads, key=lambda item: str(item.get("filename", "")), reverse=False
     )
     for download in sorted_downloads:
+        filename = download.get("filename", "")
         torrent_li = build_list_item(
-            f"{formatted_type} - {download.get('filename')}", "download.png"
+            f"{formatted_type} - {filename}", "download.png"
         )
         torrent_li.setProperty("IsPlayable", "true")
+        direct_url = download.get("download", "")
+        context_menu = [
+            (
+                translation(90791),
+                action_url_run(
+                    "download_cloud_file",
+                    url=direct_url,
+                    filename=filename,
+                    mode="movie",
+                    debrid_type=debrid_type,
+                ),
+            )
+        ]
+        torrent_li.addContextMenuItems(context_menu)
         addDirectoryItem(
             ADDON_HANDLE,
             build_url(
                 "play_info_hash",
-                url=download.get("download"),
-                title=download.get("filename"),
+                url=direct_url,
+                title=filename,
                 debrid_type=debrid_type,
             ),
             torrent_li,
@@ -258,16 +274,31 @@ def get_tb_downloads(params):
     ) if params.get("debug") else None
 
     for download in sorted_downloads:
+        name = download.get("name", "")
         torrent_li = build_list_item(
-            f"{formatted_type} - {download.get('name')}", "download.png"
+            f"{formatted_type} - {name}", "download.png"
         )
         torrent_li.setProperty("IsPlayable", "true")
+        context_menu = [
+            (
+                translation(90791),
+                action_url_run(
+                    "download_cloud_file",
+                    torrent_id=download.get("torrent_id", ""),
+                    file_id=download.get("file_id", ""),
+                    filename=name,
+                    mode="movie",
+                    debrid_type=debrid_type,
+                ),
+            )
+        ]
+        torrent_li.addContextMenuItems(context_menu)
         addDirectoryItem(
             ADDON_HANDLE,
             build_url(
                 "play_media",
                 data={
-                    "title": download.get("name"),
+                    "title": name,
                     "url": "",
                     "mode": "movie",
                     "type": IndexerType.DEBRID,
@@ -291,6 +322,35 @@ def download(magnet, debrid_type):
         notification(translation(90424))
         return
     handler(magnet)
+
+
+def resolve_cloud_download_url(data):
+    debrid_type = data.get("debrid_type", "")
+    if debrid_type == "RD":
+        url = data.get("url", "")
+        return url if url else None
+    elif debrid_type == "TB":
+        torrent_id = data.get("torrent_id", "")
+        file_id = data.get("file_id", "")
+        if not torrent_id or not file_id:
+            return None
+        cache_key = f"tb_download_link|{torrent_id}|{file_id}"
+        cached_url = cache.get(cache_key)
+        if cached_url:
+            return cached_url
+        try:
+            response = TorboxHelper().client.create_download_link(
+                torrent_id, file_id, get_public_ip()
+            )
+            if response:
+                url = response.get("data", "")
+                if url:
+                    cache.set(cache_key, url, timedelta(minutes=5))
+                    return url
+        except Exception as e:
+            kodilog(f"[resolve_cloud_download_url] TB link resolution failed: {e}")
+        return None
+    return None
 
 
 def rd_auth(params):

--- a/lib/navigation.py
+++ b/lib/navigation.py
@@ -1070,7 +1070,29 @@ def download(magnet, type):
 
 
 def downloads_menu(params):
-    downloads_viewer(params)
+    set_pluging_category(translation(90015))
+    addDirectoryItem(
+        ADDON_HANDLE,
+        build_url("downloads_viewer"),
+        build_list_item(translation(90806), "download2.png"),
+        isFolder=True,
+    )
+    addDirectoryItem(
+        ADDON_HANDLE,
+        build_url("open_download_manager"),
+        build_list_item(translation(90805), "download2.png"),
+        isFolder=False,
+    )
+    end_of_directory(cache=False)
+    apply_section_view("view.main")
+
+
+def open_download_manager(params):
+    from lib.gui.download_manager_window import DownloadManagerWindow
+
+    window = DownloadManagerWindow("download_manager.xml", ADDON_PATH)
+    window.doModal()
+    del window
 
 
 def addon_update(params):

--- a/lib/router.py
+++ b/lib/router.py
@@ -77,6 +77,9 @@ _DOWNLOAD_ACTIONS = frozenset(
         "handle_delete_file",
         "downloads_menu",
         "resume_download",
+        "download_cloud_file",
+        "open_download_manager",
+        "downloads_viewer",
     }
 )
 
@@ -537,6 +540,8 @@ def _route_downloads(action, params):
         "handle_pause_download",
         "handle_delete_file",
         "resume_download",
+        "download_cloud_file",
+        "downloads_viewer",
     ):
         from lib.downloader import (
             download_video,
@@ -545,6 +550,8 @@ def _route_downloads(action, params):
             handle_pause_download,
             handle_delete_file,
             resume_download,
+            download_cloud_file,
+            downloads_viewer,
         )
 
         actions = {
@@ -554,12 +561,18 @@ def _route_downloads(action, params):
             "handle_pause_download": handle_pause_download,
             "handle_delete_file": handle_delete_file,
             "resume_download": resume_download,
+            "download_cloud_file": download_cloud_file,
+            "downloads_viewer": downloads_viewer,
         }
         actions[action](params)
     elif action == "downloads_menu":
         from lib.navigation import downloads_menu
 
         downloads_menu(params)
+    elif action == "open_download_manager":
+        from lib.navigation import open_download_manager
+
+        open_download_manager(params)
 
 
 def _route_mdblist(action, params):

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -4322,3 +4322,11 @@ msgstr ""
 msgctxt "#90808"
 msgid "Close"
 msgstr ""
+
+msgctxt "#90809"
+msgid "Delete download?"
+msgstr ""
+
+msgctxt "#90810"
+msgid "This will permanently delete the downloaded file. Are you sure?"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -4330,3 +4330,7 @@ msgstr ""
 msgctxt "#90810"
 msgid "This will permanently delete the downloaded file. Are you sure?"
 msgstr ""
+
+msgctxt "#90811"
+msgid "Completed"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -4250,3 +4250,67 @@ msgstr ""
 msgctxt "#90790"
 msgid "Display a notification when widgets are refreshed"
 msgstr ""
+
+msgctxt "#90791"
+msgid "Download to Device"
+msgstr ""
+
+msgctxt "#90792"
+msgid "Download Manager"
+msgstr ""
+
+msgctxt "#90793"
+msgid "No active downloads"
+msgstr ""
+
+msgctxt "#90794"
+msgid "Progress"
+msgstr ""
+
+msgctxt "#90795"
+msgid "Speed"
+msgstr ""
+
+msgctxt "#90796"
+msgid "ETA"
+msgstr ""
+
+msgctxt "#90797"
+msgid "Size"
+msgstr ""
+
+msgctxt "#90798"
+msgid "Pause"
+msgstr ""
+
+msgctxt "#90799"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#90800"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#90801"
+msgid "Delete"
+msgstr ""
+
+msgctxt "#90802"
+msgid "Clear Completed"
+msgstr ""
+
+msgctxt "#90803"
+msgid "Download not yet completed"
+msgstr ""
+
+msgctxt "#90804"
+msgid "File not found"
+msgstr ""
+
+msgctxt "#90805"
+msgid "Download Manager"
+msgstr ""
+
+msgctxt "#90806"
+msgid "My Downloads"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -4314,3 +4314,11 @@ msgstr ""
 msgctxt "#90806"
 msgid "My Downloads"
 msgstr ""
+
+msgctxt "#90807"
+msgid "Connecting..."
+msgstr ""
+
+msgctxt "#90808"
+msgid "Close"
+msgstr ""

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -3866,3 +3866,87 @@ msgstr "Mostrar notificação de atualização"
 msgctxt "#90790"
 msgid "Display a notification when widgets are refreshed"
 msgstr "Mostrar uma notificação quando os widgets são atualizados"
+
+msgctxt "#90791"
+msgid "Download to Device"
+msgstr "Baixar para o dispositivo"
+
+msgctxt "#90792"
+msgid "Download Manager"
+msgstr "Gerenciador de downloads"
+
+msgctxt "#90793"
+msgid "No active downloads"
+msgstr "Nenhum download ativo"
+
+msgctxt "#90794"
+msgid "Progress"
+msgstr "Progresso"
+
+msgctxt "#90795"
+msgid "Speed"
+msgstr "Velocidade"
+
+msgctxt "#90796"
+msgid "ETA"
+msgstr "Tempo restante"
+
+msgctxt "#90797"
+msgid "Size"
+msgstr "Tamanho"
+
+msgctxt "#90798"
+msgid "Pause"
+msgstr "Pausar"
+
+msgctxt "#90799"
+msgid "Resume"
+msgstr "Retomar"
+
+msgctxt "#90800"
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgctxt "#90801"
+msgid "Delete"
+msgstr "Excluir"
+
+msgctxt "#90802"
+msgid "Clear Completed"
+msgstr "Limpar concluídos"
+
+msgctxt "#90803"
+msgid "Download not yet completed"
+msgstr "Download ainda não concluído"
+
+msgctxt "#90804"
+msgid "File not found"
+msgstr "Arquivo não encontrado"
+
+msgctxt "#90805"
+msgid "Download Manager"
+msgstr "Gerenciador de downloads"
+
+msgctxt "#90806"
+msgid "My Downloads"
+msgstr "Meus downloads"
+
+msgctxt "#90807"
+msgid "Connecting..."
+msgstr "Conectando..."
+
+msgctxt "#90808"
+msgid "Close"
+msgstr "Fechar"
+
+msgctxt "#90809"
+msgid "Delete download?"
+msgstr "Excluir download?"
+
+msgctxt "#90810"
+msgid "This will permanently delete the downloaded file. Are you sure?"
+msgstr "Isso excluirá permanentemente o arquivo baixado. Tem certeza?"
+
+msgctxt "#90811"
+msgid "Completed"
+msgstr "Concluído"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -3867,3 +3867,87 @@ msgstr "Mostrar notificação de atualização"
 msgctxt "#90790"
 msgid "Display a notification when widgets are refreshed"
 msgstr "Mostrar uma notificação quando os widgets são atualizados"
+
+msgctxt "#90791"
+msgid "Download to Device"
+msgstr "Transferir para o dispositivo"
+
+msgctxt "#90792"
+msgid "Download Manager"
+msgstr "Gestor de transferências"
+
+msgctxt "#90793"
+msgid "No active downloads"
+msgstr "Sem transferências ativas"
+
+msgctxt "#90794"
+msgid "Progress"
+msgstr "Progresso"
+
+msgctxt "#90795"
+msgid "Speed"
+msgstr "Velocidade"
+
+msgctxt "#90796"
+msgid "ETA"
+msgstr "Tempo restante"
+
+msgctxt "#90797"
+msgid "Size"
+msgstr "Tamanho"
+
+msgctxt "#90798"
+msgid "Pause"
+msgstr "Pausa"
+
+msgctxt "#90799"
+msgid "Resume"
+msgstr "Retomar"
+
+msgctxt "#90800"
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgctxt "#90801"
+msgid "Delete"
+msgstr "Eliminar"
+
+msgctxt "#90802"
+msgid "Clear Completed"
+msgstr "Limpar concluídas"
+
+msgctxt "#90803"
+msgid "Download not yet completed"
+msgstr "Transferência ainda não concluída"
+
+msgctxt "#90804"
+msgid "File not found"
+msgstr "Ficheiro não encontrado"
+
+msgctxt "#90805"
+msgid "Download Manager"
+msgstr "Gestor de transferências"
+
+msgctxt "#90806"
+msgid "My Downloads"
+msgstr "Minhas transferências"
+
+msgctxt "#90807"
+msgid "Connecting..."
+msgstr "A conectar..."
+
+msgctxt "#90808"
+msgid "Close"
+msgstr "Fechar"
+
+msgctxt "#90809"
+msgid "Delete download?"
+msgstr "Eliminar transferência?"
+
+msgctxt "#90810"
+msgid "This will permanently delete the downloaded file. Are you sure?"
+msgstr "Isto eliminará permanentemente o ficheiro transferido. Tem a certeza?"
+
+msgctxt "#90811"
+msgid "Completed"
+msgstr "Concluída"

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -4250,3 +4250,87 @@ msgstr "Afișați notificarea de reîmprospătare"
 msgctxt "#90790"
 msgid "Display a notification when widgets are refreshed"
 msgstr "Afișați o notificare când widget-urile sunt reîmprospătate"
+
+msgctxt "#90791"
+msgid "Download to Device"
+msgstr "Descarcă pe dispozitiv"
+
+msgctxt "#90792"
+msgid "Download Manager"
+msgstr "Manager de descărcări"
+
+msgctxt "#90793"
+msgid "No active downloads"
+msgstr "Nicio descărcare activă"
+
+msgctxt "#90794"
+msgid "Progress"
+msgstr "Progres"
+
+msgctxt "#90795"
+msgid "Speed"
+msgstr "Viteză"
+
+msgctxt "#90796"
+msgid "ETA"
+msgstr "Timp rămas"
+
+msgctxt "#90797"
+msgid "Size"
+msgstr "Dimensiune"
+
+msgctxt "#90798"
+msgid "Pause"
+msgstr "Pauză"
+
+msgctxt "#90799"
+msgid "Resume"
+msgstr "Relua"
+
+msgctxt "#90800"
+msgid "Cancel"
+msgstr "Anulare"
+
+msgctxt "#90801"
+msgid "Delete"
+msgstr "Șterge"
+
+msgctxt "#90802"
+msgid "Clear Completed"
+msgstr "Șterge completate"
+
+msgctxt "#90803"
+msgid "Download not yet completed"
+msgstr "Descărcarea nu este încă finalizată"
+
+msgctxt "#90804"
+msgid "File not found"
+msgstr "Fișier negăsit"
+
+msgctxt "#90805"
+msgid "Download Manager"
+msgstr "Manager de descărcări"
+
+msgctxt "#90806"
+msgid "My Downloads"
+msgstr "Descărcările mele"
+
+msgctxt "#90807"
+msgid "Connecting..."
+msgstr "Se conectează..."
+
+msgctxt "#90808"
+msgid "Close"
+msgstr "Închide"
+
+msgctxt "#90809"
+msgid "Delete download?"
+msgstr "Ștergeți descărcarea?"
+
+msgctxt "#90810"
+msgid "This will permanently delete the downloaded file. Are you sure?"
+msgstr "Acest lucru va șterge permanent fișierul descărcat. Sunteți sigur?"
+
+msgctxt "#90811"
+msgid "Completed"
+msgstr "Finalizat"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -3866,3 +3866,87 @@ msgstr "Pokazyvat uvedomleniye ob obnovlenii"
 msgctxt "#90790"
 msgid "Display a notification when widgets are refreshed"
 msgstr "Otobrazhat uvedomleniye pri obnovlenii vidzhetov"
+
+msgctxt "#90791"
+msgid "Download to Device"
+msgstr "Zagruzit na ustroystvo"
+
+msgctxt "#90792"
+msgid "Download Manager"
+msgstr "Menedzher zagruzok"
+
+msgctxt "#90793"
+msgid "No active downloads"
+msgstr "Net aktivnykh zagruzok"
+
+msgctxt "#90794"
+msgid "Progress"
+msgstr "Khod vypolneniya"
+
+msgctxt "#90795"
+msgid "Speed"
+msgstr "Skorost"
+
+msgctxt "#90796"
+msgid "ETA"
+msgstr "Ostalos"
+
+msgctxt "#90797"
+msgid "Size"
+msgstr "Razmer"
+
+msgctxt "#90798"
+msgid "Pause"
+msgstr "Pauza"
+
+msgctxt "#90799"
+msgid "Resume"
+msgstr "Vozobnovit"
+
+msgctxt "#90800"
+msgid "Cancel"
+msgstr "Otmena"
+
+msgctxt "#90801"
+msgid "Delete"
+msgstr "Udalit"
+
+msgctxt "#90802"
+msgid "Clear Completed"
+msgstr "Ochistit zavershennye"
+
+msgctxt "#90803"
+msgid "Download not yet completed"
+msgstr "Zagruzka yeshchyo ne zavershena"
+
+msgctxt "#90804"
+msgid "File not found"
+msgstr "Fayl ne nayden"
+
+msgctxt "#90805"
+msgid "Download Manager"
+msgstr "Menedzher zagruzok"
+
+msgctxt "#90806"
+msgid "My Downloads"
+msgstr "Moi zagruzki"
+
+msgctxt "#90807"
+msgid "Connecting..."
+msgstr "Podklyucheniye..."
+
+msgctxt "#90808"
+msgid "Close"
+msgstr "Zakryt"
+
+msgctxt "#90809"
+msgid "Delete download?"
+msgstr "Udalit zagruzku?"
+
+msgctxt "#90810"
+msgid "This will permanently delete the downloaded file. Are you sure?"
+msgstr "Zagruzhennyy fayl budet udalyon navsegda. Vy uvereny?"
+
+msgctxt "#90811"
+msgid "Completed"
+msgstr "Zaversheno"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -3911,3 +3911,87 @@ msgstr "Mostrar notificación de actualización"
 msgctxt "#90790"
 msgid "Display a notification when widgets are refreshed"
 msgstr "Mostrar una notificación cuando se actualicen los widgets"
+
+msgctxt "#90791"
+msgid "Download to Device"
+msgstr "Descargar al dispositivo"
+
+msgctxt "#90792"
+msgid "Download Manager"
+msgstr "Gestor de descargas"
+
+msgctxt "#90793"
+msgid "No active downloads"
+msgstr "Sin descargas activas"
+
+msgctxt "#90794"
+msgid "Progress"
+msgstr "Progreso"
+
+msgctxt "#90795"
+msgid "Speed"
+msgstr "Velocidad"
+
+msgctxt "#90796"
+msgid "ETA"
+msgstr "Tiempo restante"
+
+msgctxt "#90797"
+msgid "Size"
+msgstr "Tamaño"
+
+msgctxt "#90798"
+msgid "Pause"
+msgstr "Pausar"
+
+msgctxt "#90799"
+msgid "Resume"
+msgstr "Reanudar"
+
+msgctxt "#90800"
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgctxt "#90801"
+msgid "Delete"
+msgstr "Eliminar"
+
+msgctxt "#90802"
+msgid "Clear Completed"
+msgstr "Limpiar completados"
+
+msgctxt "#90803"
+msgid "Download not yet completed"
+msgstr "Descarga aún no completada"
+
+msgctxt "#90804"
+msgid "File not found"
+msgstr "Archivo no encontrado"
+
+msgctxt "#90805"
+msgid "Download Manager"
+msgstr "Gestor de descargas"
+
+msgctxt "#90806"
+msgid "My Downloads"
+msgstr "Mis descargas"
+
+msgctxt "#90807"
+msgid "Connecting..."
+msgstr "Conectando..."
+
+msgctxt "#90808"
+msgid "Close"
+msgstr "Cerrar"
+
+msgctxt "#90809"
+msgid "Delete download?"
+msgstr "¿Eliminar descarga?"
+
+msgctxt "#90810"
+msgid "This will permanently delete the downloaded file. Are you sure?"
+msgstr "Esto eliminará permanentemente el archivo descargado. ¿Estás seguro?"
+
+msgctxt "#90811"
+msgid "Completed"
+msgstr "Completada"

--- a/resources/skins/Default/1080i/custom_progress_dialog.xml
+++ b/resources/skins/Default/1080i/custom_progress_dialog.xml
@@ -1,90 +1,143 @@
 <window type="dialog" id="12000">
     <coordinates>
-        <left>600</left>
-        <top>400</top>
-        <width>800</width>
-        <height>300</height>
+        <left>460</left>
+        <top>320</top>
+        <width>1000</width>
+        <height>440</height>
     </coordinates>
-    <defaultcontrol always="true">12005</defaultcontrol>
+    <defaultcontrol always="true">12003</defaultcontrol>
     <animation type="WindowOpen" reversible="false">
-        <effect type="zoom" start="80" end="100" center="50%,50%" delay="160" tween="back" time="240"/>
-        <effect type="fade" delay="160" end="100" time="240"/>
+        <effect type="fade" start="0" end="100" time="200" />
     </animation>
     <animation type="WindowClose" reversible="false">
-        <effect type="zoom" start="100" end="80" center="50%,50%" easing="in" tween="back" time="240"/>
-        <effect type="fade" start="100" end="0" time="240"/>
+        <effect type="fade" start="100" end="0" time="200" />
     </animation>
-    <depth>0.40</depth>
     <controls>
+        <!-- Card background -->
+        <control type="image">
+            <left>0</left>
+            <top>0</top>
+            <width>1000</width>
+            <height>440</height>
+            <texture border="20">circle.png</texture>
+            <colordiffuse>FF1A1A1A</colordiffuse>
+        </control>
+
+        <!-- Accent bar -->
+        <control type="image">
+            <left>0</left>
+            <top>0</top>
+            <width>1000</width>
+            <height>4</height>
+            <texture>white.png</texture>
+            <colordiffuse>FF00559D</colordiffuse>
+        </control>
+
         <control type="group">
-            <width>800</width>
-            <height>300</height>
-            <control type="image">
-                <width>800</width>
-                <height>300</height>
-                <texture border="30">circle.png</texture>
-                <colordiffuse>CC000000</colordiffuse>
-            </control>
+            <left>40</left>
+            <top>25</top>
+            <width>920</width>
+            <height>390</height>
+
+            <!-- Title -->
             <control type="label" id="12001">
-                <top>30</top>
-                <width>780</width>
-                <height>40</height>
+                <top>0</top>
+                <width>920</width>
+                <height>35</height>
                 <align>center</align>
-                <font>font14</font>
+                <font>font30_title</font>
                 <textcolor>white</textcolor>
                 <shadowcolor>AA000000</shadowcolor>
             </control>
+
+            <!-- File name -->
             <control type="label" id="12002">
-                <top>80</top>
-                <width>780</width>
-                <height>60</height>
+                <top>40</top>
+                <width>920</width>
+                <height>50</height>
                 <align>center</align>
-                <font>font12</font>
-                <textcolor>white</textcolor>
+                <font>font14</font>
+                <textcolor>EEEEEE</textcolor>
                 <shadowcolor>AA000000</shadowcolor>
                 <wrapmultiline>true</wrapmultiline>
             </control>
+
+            <!-- Big percentage -->
+            <control type="label" id="12006">
+                <top>100</top>
+                <width>920</width>
+                <height>70</height>
+                <align>center</align>
+                <font>font48</font>
+                <textcolor>FFFFD700</textcolor>
+                <shadowcolor>AA000000</shadowcolor>
+                <label>0%</label>
+            </control>
+
+            <!-- Details row -->
+            <control type="label" id="12007">
+                <top>175</top>
+                <left>0</left>
+                <width>455</width>
+                <height>25</height>
+                <align>left</align>
+                <font>font12</font>
+                <textcolor>CCCCCC</textcolor>
+                <label> </label>
+            </control>
+            <control type="label" id="12008">
+                <top>175</top>
+                <left>465</left>
+                <width>455</width>
+                <height>25</height>
+                <align>right</align>
+                <font>font12</font>
+                <textcolor>CCCCCC</textcolor>
+                <label> </label>
+            </control>
+
+            <!-- Progress bar -->
             <control type="progress" id="12004">
-                <top>180</top>
-                <left>40</left>
-                <width>720</width>
-                <height>20</height>
+                <top>210</top>
+                <left>0</left>
+                <width>920</width>
+                <height>24</height>
                 <info>percentage</info>
             </control>
-            <control type="grouplist" orientation="horizontal">
-                <orientation>horizontal</orientation>
-                <top>220</top>
-                <left>200</left>
-                <itemgap>100</itemgap> <!-- Adjust spacing between buttons -->
-                <!-- Cancel Button -->
+
+            <!-- Buttons -->
+            <control type="group">
+                <top>250</top>
+                <left>0</left>
+                <width>920</width>
+                <height>50</height>
+                <!-- Cancel -->
                 <control type="button" id="12003">
-                    <width>auto</width>
-                    <height>56</height>
-                    <label>Cancel</label>
+                    <left>140</left>
+                    <width>260</width>
+                    <height>50</height>
+                    <label>$ADDON[plugin.video.jacktook 90800]</label>
                     <align>center</align>
-                    <textoffsetx>20</textoffsetx>
-                    <font>font14</font>
+                    <font>font13</font>
                     <textcolor>DDFFFFFF</textcolor>
                     <focusedcolor>EEFFFFFF</focusedcolor>
-                    <selectedcolor>DDFFFFFF</selectedcolor>
-                    <texturefocus border="25" colordiffuse="FF999999">circle.png</texturefocus>
-                    <texturenofocus border="25" colordiffuse="99000000">circle.png</texturenofocus>
-                    <pulseonselect>no</pulseonselect>
+                    <texturefocus border="20" colordiffuse="FFB22222">circle.png</texturefocus>
+                    <texturenofocus border="20" colordiffuse="66000000">circle.png</texturenofocus>
+                    <onright>12005</onright>
                 </control>
-                <!-- Close Button -->
+                <!-- Close -->
                 <control type="button" id="12005">
-                    <width>auto</width>
-                    <height>56</height>
-                    <label>Close</label>
+                    <left>520</left>
+                    <width>260</width>
+                    <height>50</height>
+                    <label>$ADDON[plugin.video.jacktook 90808]</label>
                     <align>center</align>
-                    <textoffsetx>20</textoffsetx>
-                    <font>font14</font>
+                    <font>font13</font>
                     <textcolor>DDFFFFFF</textcolor>
                     <focusedcolor>EEFFFFFF</focusedcolor>
-                    <selectedcolor>DDFFFFFF</selectedcolor>
-                    <texturefocus border="25" colordiffuse="FF999999">circle.png</texturefocus>
-                    <texturenofocus border="25" colordiffuse="99000000">circle.png</texturenofocus>
-                    <pulseonselect>no</pulseonselect>
+                    <texturefocus border="20" colordiffuse="FF999999">circle.png</texturefocus>
+                    <texturenofocus border="20" colordiffuse="66000000">circle.png</texturenofocus>
+                    <onleft>12003</onleft>
                 </control>
             </control>
         </control>

--- a/resources/skins/Default/1080i/download_manager.xml
+++ b/resources/skins/Default/1080i/download_manager.xml
@@ -111,52 +111,56 @@
                 <onright>14003</onright>
                 <ondown>14003</ondown>
                 <visible>!String.IsEqual(Window.Property(downloads_empty),true)</visible>
-                <itemlayout height="50">
+<itemlayout height="65">
                     <control type="image">
-                        <left>0</left>
-                        <width>1200</width>
-                        <height>50</height>
-                        <texture>white.png</texture>
-                        <colordiffuse>33000000</colordiffuse>
+                        <left>5</left>
+                        <top>4</top>
+                        <width>1190</width>
+                        <height>53</height>
+                        <texture border="20">circle.png</texture>
+                        <colordiffuse>2AFFFFFF</colordiffuse>
                     </control>
                     <control type="label">
                         <left>20</left>
                         <width>800</width>
-                        <height>50</height>
+                        <height>65</height>
                         <font>font13</font>
-                        <textcolor>EEEEEE</textcolor>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <shadowcolor>AA000000</shadowcolor>
                         <label>$INFO[ListItem.Label]</label>
                     </control>
                     <control type="label">
                         <left>840</left>
                         <width>340</width>
-                        <height>50</height>
+                        <height>65</height>
                         <font>font13</font>
                         <align>right</align>
-                        <textcolor>EEEEEE</textcolor>
+                        <textcolor>FFAAAAAA</textcolor>
                         <label>$INFO[ListItem.Property(entry_status)]</label>
                     </control>
                 </itemlayout>
-                <focusedlayout height="50">
+                <focusedlayout height="65">
                     <control type="image">
-                        <left>0</left>
-                        <width>1200</width>
-                        <height>50</height>
+                        <left>5</left>
+                        <top>4</top>
+                        <width>1190</width>
+                        <height>53</height>
                         <texture border="20">circle.png</texture>
                         <colordiffuse>992A3E5C</colordiffuse>
                     </control>
                     <control type="label">
                         <left>20</left>
                         <width>800</width>
-                        <height>50</height>
+                        <height>65</height>
                         <font>font13</font>
-                        <textcolor>white</textcolor>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <shadowcolor>AA000000</shadowcolor>
                         <label>$INFO[ListItem.Label]</label>
                     </control>
                     <control type="label">
                         <left>840</left>
                         <width>340</width>
-                        <height>50</height>
+                        <height>65</height>
                         <font>font13</font>
                         <align>right</align>
                         <textcolor>FFFFD700</textcolor>

--- a/resources/skins/Default/1080i/download_manager.xml
+++ b/resources/skins/Default/1080i/download_manager.xml
@@ -61,13 +61,32 @@
             <!-- Title -->
             <control type="label">
                 <top>0</top>
-                <width>1200</width>
+                <width>1100</width>
                 <height>50</height>
                 <align>center</align>
                 <font>font30_title</font>
                 <textcolor>white</textcolor>
                 <shadowcolor>AA000000</shadowcolor>
                 <label>$ADDON[plugin.video.jacktook 90792]</label>
+            </control>
+
+            <!-- Close Button -->
+            <control type="button" id="14008">
+                <left>1120</left>
+                <top>0</top>
+                <width>80</width>
+                <height>50</height>
+                <label>X</label>
+                <align>center</align>
+                <font>font13</font>
+                <textcolor>99FFFFFF</textcolor>
+                <focusedcolor>EEFFFFFF</focusedcolor>
+                <texturefocus border="15" colordiffuse="FFB22222">circle.png</texturefocus>
+                <texturenofocus border="15" colordiffuse="66000000">circle.png</texturenofocus>
+                <onleft>14001</onleft>
+                <onright>14001</onright>
+                <ondown>14001</ondown>
+                <onup>14001</onup>
             </control>
 
             <!-- Empty message -->

--- a/resources/skins/Default/1080i/download_manager.xml
+++ b/resources/skins/Default/1080i/download_manager.xml
@@ -106,65 +106,93 @@
                 <top>70</top>
                 <left>0</left>
                 <width>1200</width>
-                <height>500</height>
+                <height>560</height>
                 <onleft>14003</onleft>
                 <onright>14003</onright>
                 <ondown>14003</ondown>
                 <visible>!String.IsEqual(Window.Property(downloads_empty),true)</visible>
-<itemlayout height="65">
+                <itemlayout height="80">
                     <control type="image">
                         <left>5</left>
                         <top>4</top>
                         <width>1190</width>
-                        <height>53</height>
+                        <height>72</height>
                         <texture border="20">circle.png</texture>
                         <colordiffuse>2AFFFFFF</colordiffuse>
                     </control>
+                    <!-- Line 1: Filename -->
                     <control type="label">
                         <left>20</left>
-                        <width>800</width>
-                        <height>65</height>
+                        <top>6</top>
+                        <width>900</width>
+                        <height>32</height>
                         <font>font13</font>
                         <textcolor>FFFFFFFF</textcolor>
                         <shadowcolor>AA000000</shadowcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$INFO[ListItem.Property(entry_name)]</label>
                     </control>
+                    <!-- Line 1 right: Progress % -->
                     <control type="label">
-                        <left>840</left>
-                        <width>340</width>
-                        <height>65</height>
+                        <left>940</left>
+                        <top>6</top>
+                        <width>240</width>
+                        <height>32</height>
                         <font>font13</font>
                         <align>right</align>
                         <textcolor>FFAAAAAA</textcolor>
-                        <label>$INFO[ListItem.Property(entry_status)]</label>
+                        <label>$INFO[ListItem.Property(entry_progress)]%</label>
+                    </control>
+                    <!-- Line 2: Speed • ETA • Downloaded/Size -->
+                    <control type="label">
+                        <left>20</left>
+                        <top>38</top>
+                        <width>1160</width>
+                        <height>28</height>
+                        <font>font10</font>
+                        <textcolor>FF999999</textcolor>
+                        <label>$INFO[ListItem.Property(entry_info)]</label>
                     </control>
                 </itemlayout>
-                <focusedlayout height="65">
+                <focusedlayout height="80">
                     <control type="image">
                         <left>5</left>
                         <top>4</top>
                         <width>1190</width>
-                        <height>53</height>
+                        <height>72</height>
                         <texture border="20">circle.png</texture>
                         <colordiffuse>992A3E5C</colordiffuse>
                     </control>
+                    <!-- Line 1: Filename -->
                     <control type="label">
                         <left>20</left>
-                        <width>800</width>
-                        <height>65</height>
+                        <top>6</top>
+                        <width>900</width>
+                        <height>32</height>
                         <font>font13</font>
                         <textcolor>FFFFFFFF</textcolor>
                         <shadowcolor>AA000000</shadowcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$INFO[ListItem.Property(entry_name)]</label>
                     </control>
+                    <!-- Line 1 right: Status badge + progress -->
                     <control type="label">
-                        <left>840</left>
-                        <width>340</width>
-                        <height>65</height>
+                        <left>940</left>
+                        <top>6</top>
+                        <width>240</width>
+                        <height>32</height>
                         <font>font13</font>
                         <align>right</align>
                         <textcolor>FFFFD700</textcolor>
-                        <label>$INFO[ListItem.Property(entry_status)]</label>
+                        <label>$INFO[ListItem.Property(entry_progress)]%</label>
+                    </control>
+                    <!-- Line 2: Speed • ETA • Downloaded/Size -->
+                    <control type="label">
+                        <left>20</left>
+                        <top>38</top>
+                        <width>1160</width>
+                        <height>28</height>
+                        <font>font10</font>
+                        <textcolor>FFCCCCCC</textcolor>
+                        <label>$INFO[ListItem.Property(entry_info)]</label>
                     </control>
                 </focusedlayout>
             </control>

--- a/resources/skins/Default/1080i/download_manager.xml
+++ b/resources/skins/Default/1080i/download_manager.xml
@@ -1,0 +1,307 @@
+<window type="dialog" id="14000">
+    <coordinates>
+        <left>0</left>
+        <top>0</top>
+        <width>1920</width>
+        <height>1080</height>
+    </coordinates>
+    <defaultcontrol always="true">14002</defaultcontrol>
+    <animation type="WindowOpen" reversible="false">
+        <effect type="fade" start="0" end="100" time="300" />
+    </animation>
+    <animation type="WindowClose" reversible="false">
+        <effect type="fade" start="100" end="0" time="300" />
+    </animation>
+    <controls>
+        <!-- Background Fanart -->
+        <control type="image">
+            <left>0</left>
+            <top>0</top>
+            <width>1920</width>
+            <height>1080</height>
+            <texture background="true">$INFO[Window.Property(info.fanart)]</texture>
+            <aspectratio align="center" aligny="center">scale</aspectratio>
+        </control>
+        <!-- Solid dark overlay -->
+        <control type="image">
+            <left>0</left>
+            <top>0</top>
+            <width>1920</width>
+            <height>1080</height>
+            <texture>white.png</texture>
+            <colordiffuse>CC000000</colordiffuse>
+        </control>
+
+        <!-- Main Card Background -->
+        <control type="image">
+            <left>340</left>
+            <top>100</top>
+            <width>1240</width>
+            <height>880</height>
+            <texture border="20">circle.png</texture>
+            <colordiffuse>FF1A1A1A</colordiffuse>
+        </control>
+
+        <!-- Accent Bar (top) -->
+        <control type="image">
+            <left>340</left>
+            <top>100</top>
+            <width>1240</width>
+            <height>4</height>
+            <texture>white.png</texture>
+            <colordiffuse>FF00559D</colordiffuse>
+        </control>
+
+        <control type="group">
+            <left>360</left>
+            <top>120</top>
+            <width>1200</width>
+            <height>840</height>
+
+            <!-- Title -->
+            <control type="label">
+                <top>0</top>
+                <width>1200</width>
+                <height>50</height>
+                <align>center</align>
+                <font>font30_title</font>
+                <textcolor>white</textcolor>
+                <shadowcolor>AA000000</shadowcolor>
+                <label>$ADDON[plugin.video.jacktook 90792]</label>
+            </control>
+
+            <!-- Empty message -->
+            <control type="label">
+                <top>250</top>
+                <width>1200</width>
+                <height>50</height>
+                <align>center</align>
+                <font>font13</font>
+                <textcolor>EEEEEE</textcolor>
+                <label>$ADDON[plugin.video.jacktook 90793]</label>
+                <visible>String.IsEqual(Window.Property(downloads_empty),true)</visible>
+            </control>
+
+            <!-- Download List -->
+            <control type="list" id="14001">
+                <top>70</top>
+                <left>0</left>
+                <width>1200</width>
+                <height>500</height>
+                <onleft>14003</onleft>
+                <onright>14003</onright>
+                <ondown>14003</ondown>
+                <visible>!String.IsEqual(Window.Property(downloads_empty),true)</visible>
+                <itemlayout height="50">
+                    <control type="image">
+                        <left>0</left>
+                        <width>1200</width>
+                        <height>50</height>
+                        <texture>white.png</texture>
+                        <colordiffuse>33000000</colordiffuse>
+                    </control>
+                    <control type="label">
+                        <left>20</left>
+                        <width>800</width>
+                        <height>50</height>
+                        <font>font13</font>
+                        <textcolor>EEEEEE</textcolor>
+                        <label>$INFO[ListItem.Label]</label>
+                    </control>
+                    <control type="label">
+                        <left>840</left>
+                        <width>340</width>
+                        <height>50</height>
+                        <font>font13</font>
+                        <align>right</align>
+                        <textcolor>EEEEEE</textcolor>
+                        <label>$INFO[ListItem.Property(entry_status)]</label>
+                    </control>
+                </itemlayout>
+                <focusedlayout height="50">
+                    <control type="image">
+                        <left>0</left>
+                        <width>1200</width>
+                        <height>50</height>
+                        <texture border="20">circle.png</texture>
+                        <colordiffuse>992A3E5C</colordiffuse>
+                    </control>
+                    <control type="label">
+                        <left>20</left>
+                        <width>800</width>
+                        <height>50</height>
+                        <font>font13</font>
+                        <textcolor>white</textcolor>
+                        <label>$INFO[ListItem.Label]</label>
+                    </control>
+                    <control type="label">
+                        <left>840</left>
+                        <width>340</width>
+                        <height>50</height>
+                        <font>font13</font>
+                        <align>right</align>
+                        <textcolor>FFFFD700</textcolor>
+                        <label>$INFO[ListItem.Property(entry_status)]</label>
+                    </control>
+                </focusedlayout>
+            </control>
+
+            <!-- Details Panel -->
+            <control type="group">
+                <top>580</top>
+                <left>0</left>
+                <width>1200</width>
+                <height>120</height>
+                <visible>!String.IsEqual(Window.Property(downloads_empty),true)</visible>
+                <control type="image">
+                    <left>0</left>
+                    <width>1200</width>
+                    <height>120</height>
+                    <texture border="20">circle.png</texture>
+                    <colordiffuse>66000000</colordiffuse>
+                </control>
+                <control type="label">
+                    <left>20</left>
+                    <top>10</top>
+                    <width>580</width>
+                    <height>30</height>
+                    <font>font13</font>
+                    <textcolor>white</textcolor>
+                    <label>$ADDON[plugin.video.jacktook 90794]: $INFO[Window.Property(selected_progress)]%</label>
+                </control>
+                <control type="label">
+                    <left>620</left>
+                    <top>10</top>
+                    <width>580</width>
+                    <height>30</height>
+                    <font>font13</font>
+                    <textcolor>white</textcolor>
+                    <label>$ADDON[plugin.video.jacktook 90795]: $INFO[Window.Property(selected_speed)]</label>
+                </control>
+                <control type="label">
+                    <left>20</left>
+                    <top>50</top>
+                    <width>580</width>
+                    <height>30</height>
+                    <font>font13</font>
+                    <textcolor>white</textcolor>
+                    <label>$ADDON[plugin.video.jacktook 90796]: $INFO[Window.Property(selected_eta)]</label>
+                </control>
+                <control type="label">
+                    <left>620</left>
+                    <top>50</top>
+                    <width>580</width>
+                    <height>30</height>
+                    <font>font13</font>
+                    <textcolor>white</textcolor>
+                    <label>$ADDON[plugin.video.jacktook 90797]: $INFO[Window.Property(selected_size)]</label>
+                </control>
+            </control>
+
+            <!-- Action Buttons -->
+            <control type="group">
+                <top>720</top>
+                <left>0</left>
+                <width>1200</width>
+                <height>60</height>
+                <visible>!String.IsEqual(Window.Property(downloads_empty),true)</visible>
+                <!-- Pause -->
+                <control type="button" id="14003">
+                    <left>0</left>
+                    <width>230</width>
+                    <height>60</height>
+                    <label>$ADDON[plugin.video.jacktook 90798]</label>
+                    <align>center</align>
+                    <font>font13</font>
+                    <textcolor>DDFFFFFF</textcolor>
+                    <focusedcolor>EEFFFFFF</focusedcolor>
+                    <texturefocus border="25" colordiffuse="FF999999">circle.png</texturefocus>
+                    <texturenofocus border="25" colordiffuse="99000000">circle.png</texturenofocus>
+                    <onleft>14007</onleft>
+                    <onright>14004</onright>
+                    <onup>14001</onup>
+                    <ondown>14001</ondown>
+                </control>
+                <!-- Resume -->
+                <control type="button" id="14004">
+                    <left>240</left>
+                    <width>230</width>
+                    <height>60</height>
+                    <label>$ADDON[plugin.video.jacktook 90799]</label>
+                    <align>center</align>
+                    <font>font13</font>
+                    <textcolor>DDFFFFFF</textcolor>
+                    <focusedcolor>EEFFFFFF</focusedcolor>
+                    <texturefocus border="25" colordiffuse="FF999999">circle.png</texturefocus>
+                    <texturenofocus border="25" colordiffuse="99000000">circle.png</texturenofocus>
+                    <onleft>14003</onleft>
+                    <onright>14005</onright>
+                    <onup>14001</onup>
+                    <ondown>14001</ondown>
+                </control>
+                <!-- Cancel -->
+                <control type="button" id="14005">
+                    <left>480</left>
+                    <width>230</width>
+                    <height>60</height>
+                    <label>$ADDON[plugin.video.jacktook 90800]</label>
+                    <align>center</align>
+                    <font>font13</font>
+                    <textcolor>DDFFFFFF</textcolor>
+                    <focusedcolor>EEFFFFFF</focusedcolor>
+                    <texturefocus border="25" colordiffuse="FF999999">circle.png</texturefocus>
+                    <texturenofocus border="25" colordiffuse="99000000">circle.png</texturenofocus>
+                    <onleft>14004</onleft>
+                    <onright>14006</onright>
+                    <onup>14001</onup>
+                    <ondown>14001</ondown>
+                </control>
+                <!-- Delete -->
+                <control type="button" id="14006">
+                    <left>720</left>
+                    <width>230</width>
+                    <height>60</height>
+                    <label>$ADDON[plugin.video.jacktook 90801]</label>
+                    <align>center</align>
+                    <font>font13</font>
+                    <textcolor>DDFFFFFF</textcolor>
+                    <focusedcolor>EEFFFFFF</focusedcolor>
+                    <texturefocus border="25" colordiffuse="FF999999">circle.png</texturefocus>
+                    <texturenofocus border="25" colordiffuse="99000000">circle.png</texturenofocus>
+                    <onleft>14005</onleft>
+                    <onright>14007</onright>
+                    <onup>14001</onup>
+                    <ondown>14001</ondown>
+                </control>
+                <!-- Clear Completed -->
+                <control type="button" id="14007">
+                    <left>960</left>
+                    <width>240</width>
+                    <height>60</height>
+                    <label>$ADDON[plugin.video.jacktook 90802]</label>
+                    <align>center</align>
+                    <font>font13</font>
+                    <textcolor>DDFFFFFF</textcolor>
+                    <focusedcolor>EEFFFFFF</focusedcolor>
+                    <texturefocus border="25" colordiffuse="FF999999">circle.png</texturefocus>
+                    <texturenofocus border="25" colordiffuse="99000000">circle.png</texturenofocus>
+                    <onleft>14006</onleft>
+                    <onright>14003</onright>
+                    <onup>14001</onup>
+                    <ondown>14001</ondown>
+                </control>
+            </control>
+
+            <!-- Hidden Refresh Button — must be visible for focus, but 1x1px with no texture -->
+            <control type="button" id="14002">
+                <left>0</left>
+                <top>0</top>
+                <width>1</width>
+                <height>1</height>
+                <texturefocus>-</texturefocus>
+                <texturenofocus>-</texturenofocus>
+                <label></label>
+            </control>
+        </control>
+    </controls>
+</window>

--- a/tests/unit/test_cloud_download.py
+++ b/tests/unit/test_cloud_download.py
@@ -152,6 +152,7 @@ class TestDownloadCloudFile:
         downloader = _load_downloader_module()
 
         with tempfile.TemporaryDirectory() as tmpdir:
+            movies_dir = os.path.join(tmpdir, "Movies")
             with patch.object(downloader, "get_setting", side_effect=lambda key, default="": {
                 "download_dir": tmpdir,
                 "organize_downloads": True,
@@ -165,9 +166,7 @@ class TestDownloadCloudFile:
                 downloader, "Downloader"
             ) as mock_downloader_cls, patch.object(
                 downloader.xbmcvfs, "mkdirs"
-            ) as mock_mkdirs, patch.object(
-                downloader.os.path, "exists", return_value=True
-            ):
+            ) as mock_mkdirs:
                 mock_downloader = MagicMock()
                 mock_downloader_cls.return_value = mock_downloader
 
@@ -178,11 +177,10 @@ class TestDownloadCloudFile:
                     "debrid_type": "RD",
                 })
 
-                expected_dest = os.path.join(tmpdir, "Movies")
-                mock_mkdirs.assert_called_once_with(expected_dest)
+                mock_mkdirs.assert_called_once_with(movies_dir)
                 call_kwargs = mock_downloader_cls.call_args.kwargs
-                assert call_kwargs["destination"] == expected_dest
-                assert call_kwargs["registry_id"] == os.path.join(expected_dest, "Movie.mkv")
+                assert call_kwargs["destination"] == movies_dir
+                assert call_kwargs["registry_id"] == os.path.join(movies_dir, "Movie.mkv")
 
     def test_get_rd_downloads_adds_menu_even_without_url(self):
         debrid = __import__("lib.nav.debrid", fromlist=["get_rd_downloads"])

--- a/tests/unit/test_cloud_download.py
+++ b/tests/unit/test_cloud_download.py
@@ -1,0 +1,303 @@
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Ensure Kodi modules are mocked before importing lib modules
+sys.modules.setdefault("xbmc", MagicMock())
+sys.modules.setdefault("xbmcgui", MagicMock())
+sys.modules.setdefault("xbmcplugin", MagicMock())
+sys.modules.setdefault("xbmcvfs", MagicMock())
+sys.modules.setdefault("xbmcaddon", MagicMock())
+
+
+from lib.download_manager import DownloadManager
+
+
+def _load_downloader_module():
+    import importlib
+
+    if "lib.downloader" in sys.modules:
+        return importlib.reload(sys.modules["lib.downloader"])
+    return importlib.import_module("lib.downloader")
+
+
+class TestDownloadCloudFile:
+    def setup_method(self):
+        DownloadManager().clear()
+
+    def test_download_cloud_file_rd_registers_and_starts(self):
+        downloader = _load_downloader_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(downloader, "get_setting", side_effect=lambda key, default="": {
+                "download_dir": tmpdir,
+                "organize_downloads": False,
+            }.get(key, default)), patch.object(
+                downloader, "translatePath", return_value=tmpdir
+            ), patch.object(
+                downloader, "normalize_file_name", return_value="Movie.mkv"
+            ), patch.object(
+                downloader, "Downloader"
+            ) as mock_downloader_cls:
+                mock_downloader = MagicMock()
+                mock_downloader_cls.return_value = mock_downloader
+
+                downloader.download_cloud_file({
+                    "url": "https://example.com/Movie.mkv",
+                    "filename": "Movie.mkv",
+                    "mode": "movie",
+                    "debrid_type": "RD",
+                })
+
+                manager = DownloadManager()
+                entries = manager.list_entries()
+                assert len(entries) == 1
+                assert entries[0].name == "Movie.mkv"
+                assert entries[0].status == "downloading"
+                assert entries[0].url == "https://example.com/Movie.mkv"
+                assert entries[0].thread is not None
+
+                mock_downloader_cls.assert_called_once()
+                call_kwargs = mock_downloader_cls.call_args.kwargs
+                assert call_kwargs["url"] == "https://example.com/Movie.mkv"
+                assert call_kwargs["name"] == "Movie.mkv"
+                assert call_kwargs["destination"] == tmpdir
+                assert call_kwargs["registry_id"] is not None
+                mock_downloader.run.assert_called_once()
+
+    def test_download_cloud_file_tb_resolves_link_and_starts(self):
+        downloader = _load_downloader_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(downloader, "get_setting", side_effect=lambda key, default="": {
+                "download_dir": tmpdir,
+                "organize_downloads": False,
+            }.get(key, default)), patch.object(
+                downloader, "translatePath", return_value=tmpdir
+            ), patch.object(
+                downloader, "normalize_file_name", return_value="Movie.mkv"
+            ), patch.object(
+                downloader, "Downloader"
+            ) as mock_downloader_cls, patch.object(
+                downloader, "resolve_cloud_download_url", return_value="https://tb.example.com/Movie.mkv"
+            ) as mock_resolve:
+                mock_downloader = MagicMock()
+                mock_downloader_cls.return_value = mock_downloader
+
+                downloader.download_cloud_file({
+                    "torrent_id": "123",
+                    "file_id": "456",
+                    "filename": "Movie.mkv",
+                    "mode": "movie",
+                    "debrid_type": "TB",
+                })
+
+                mock_resolve.assert_called_once()
+                manager = DownloadManager()
+                entries = manager.list_entries()
+                assert len(entries) == 1
+                assert entries[0].url == "https://tb.example.com/Movie.mkv"
+                assert entries[0].thread is not None
+
+                call_kwargs = mock_downloader_cls.call_args.kwargs
+                assert call_kwargs["destination"] == tmpdir
+                mock_downloader.run.assert_called_once()
+
+    def test_download_cloud_file_missing_url_notifies(self):
+        downloader = _load_downloader_module()
+
+        with patch.object(downloader, "notification") as mock_notification:
+            downloader.download_cloud_file({
+                "filename": "Movie.mkv",
+                "mode": "movie",
+                "debrid_type": "RD",
+            })
+
+            mock_notification.assert_called_once()
+            manager = DownloadManager()
+            assert len(manager.list_entries()) == 0
+
+    def test_download_cloud_file_duplicate_reuses_existing(self):
+        downloader = _load_downloader_module()
+
+        manager = DownloadManager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager.register(name="Movie.mkv", dest_path=os.path.join(tmpdir, "Movie.mkv"), url="https://example.com/Movie.mkv")
+
+            with patch.object(downloader, "get_setting", side_effect=lambda key, default="": {
+                "download_dir": tmpdir,
+                "organize_downloads": False,
+            }.get(key, default)), patch.object(
+                downloader, "translatePath", return_value=tmpdir
+            ), patch.object(
+                downloader, "normalize_file_name", return_value="Movie.mkv"
+            ), patch.object(downloader, "notification") as mock_notification:
+                downloader.download_cloud_file({
+                    "url": "https://example.com/Movie.mkv",
+                    "filename": "Movie.mkv",
+                    "mode": "movie",
+                    "debrid_type": "RD",
+                })
+
+                mock_notification.assert_called_once()
+                assert len(manager.list_entries()) == 1
+
+    def test_download_cloud_file_uses_organized_destination(self):
+        downloader = _load_downloader_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(downloader, "get_setting", side_effect=lambda key, default="": {
+                "download_dir": tmpdir,
+                "organize_downloads": True,
+                "download_folder_movies": "Movies",
+                "download_folder_tvshows": "TV Shows",
+            }.get(key, default)), patch.object(
+                downloader, "translatePath", return_value=tmpdir
+            ), patch.object(
+                downloader, "normalize_file_name", return_value="Movie.mkv"
+            ), patch.object(
+                downloader, "Downloader"
+            ) as mock_downloader_cls, patch.object(
+                downloader.xbmcvfs, "mkdirs"
+            ) as mock_mkdirs, patch.object(
+                downloader.os.path, "exists", return_value=True
+            ):
+                mock_downloader = MagicMock()
+                mock_downloader_cls.return_value = mock_downloader
+
+                downloader.download_cloud_file({
+                    "url": "https://example.com/Movie.mkv",
+                    "filename": "Movie.mkv",
+                    "mode": "movie",
+                    "debrid_type": "RD",
+                })
+
+                expected_dest = os.path.join(tmpdir, "Movies")
+                mock_mkdirs.assert_called_once_with(expected_dest)
+                call_kwargs = mock_downloader_cls.call_args.kwargs
+                assert call_kwargs["destination"] == expected_dest
+                assert call_kwargs["registry_id"] == os.path.join(expected_dest, "Movie.mkv")
+
+    def test_get_rd_downloads_adds_menu_even_without_url(self):
+        debrid = __import__("lib.nav.debrid", fromlist=["get_rd_downloads"])
+
+        mock_li = MagicMock()
+        with patch.object(debrid, "build_list_item", return_value=mock_li), patch.object(
+            debrid, "get_random_color", return_value="red"
+        ), patch.object(
+            debrid, "get_setting", side_effect=lambda key, default="": "" if key == "real_debrid_token" else default
+        ), patch.object(
+            debrid.cache, "get", return_value=[{"filename": "Movie.mkv", "download": ""}]
+        ), patch.object(
+            debrid, "addDirectoryItem"
+        ), patch.object(
+            debrid, "end_of_directory"
+        ), patch.object(
+            debrid, "apply_section_view"
+        ), patch.object(
+            debrid, "action_url_run", return_value="run:download"
+        ) as mock_action:
+            debrid.get_rd_downloads({"page": 1})
+            mock_li.addContextMenuItems.assert_called_once()
+            assert mock_action.call_count == 1
+            assert mock_action.call_args.kwargs.get("url") == ""
+
+    def test_resolve_cloud_download_url_rd_returns_direct(self):
+        debrid = __import__("lib.nav.debrid", fromlist=["resolve_cloud_download_url"])
+
+        result = debrid.resolve_cloud_download_url({
+            "debrid_type": "RD",
+            "url": "https://example.com/Movie.mkv",
+        })
+        assert result == "https://example.com/Movie.mkv"
+
+    def test_resolve_cloud_download_url_rd_missing_url_returns_none(self):
+        debrid = __import__("lib.nav.debrid", fromlist=["resolve_cloud_download_url"])
+
+        result = debrid.resolve_cloud_download_url({
+            "debrid_type": "RD",
+        })
+        assert result is None
+
+    def test_resolve_cloud_download_url_tb_calls_create_link(self):
+        debrid = __import__("lib.nav.debrid", fromlist=["resolve_cloud_download_url"])
+
+        mock_client = MagicMock()
+        mock_client.create_download_link.return_value = {
+            "data": "https://tb.example.com/Movie.mkv"
+        }
+        mock_helper = MagicMock()
+        mock_helper.client = mock_client
+
+        with patch.object(debrid, "TorboxHelper", return_value=mock_helper), patch.object(
+            debrid, "get_public_ip", return_value="1.2.3.4"
+        ), patch.object(debrid.cache, "get", return_value=None), patch.object(
+            debrid.cache, "set"
+        ):
+            result = debrid.resolve_cloud_download_url({
+                "debrid_type": "TB",
+                "torrent_id": "123",
+                "file_id": "456",
+            })
+
+        assert result == "https://tb.example.com/Movie.mkv"
+        mock_client.create_download_link.assert_called_once_with("123", "456", "1.2.3.4")
+
+    def test_resolve_cloud_download_url_tb_failure_returns_none(self):
+        debrid = __import__("lib.nav.debrid", fromlist=["resolve_cloud_download_url"])
+
+        mock_client = MagicMock()
+        mock_client.create_download_link.return_value = None
+        mock_helper = MagicMock()
+        mock_helper.client = mock_client
+
+        with patch.object(debrid, "TorboxHelper", return_value=mock_helper), patch.object(
+            debrid, "get_public_ip", return_value="1.2.3.4"
+        ), patch.object(debrid.cache, "get", return_value=None), patch.object(
+            debrid.cache, "set"
+        ):
+            result = debrid.resolve_cloud_download_url({
+                "debrid_type": "TB",
+                "torrent_id": "123",
+                "file_id": "456",
+            })
+
+        assert result is None
+
+    def test_resolve_cloud_download_url_tb_caches_result(self):
+        debrid = __import__("lib.nav.debrid", fromlist=["resolve_cloud_download_url"])
+
+        mock_client = MagicMock()
+        mock_client.create_download_link.return_value = {
+            "data": "https://tb.example.com/Movie.mkv"
+        }
+        mock_helper = MagicMock()
+        mock_helper.client = mock_client
+
+        with patch.object(debrid, "TorboxHelper", return_value=mock_helper), patch.object(
+            debrid, "get_public_ip", return_value="1.2.3.4"
+        ), patch.object(debrid.cache, "get", side_effect=[None, "https://tb.example.com/Movie.mkv"]) as mock_cache_get, patch.object(
+            debrid.cache, "set"
+        ) as mock_cache_set:
+            result1 = debrid.resolve_cloud_download_url({
+                "debrid_type": "TB",
+                "torrent_id": "123",
+                "file_id": "456",
+            })
+            assert result1 == "https://tb.example.com/Movie.mkv"
+            mock_client.create_download_link.assert_called_once_with("123", "456", "1.2.3.4")
+            mock_cache_set.assert_called_once()
+
+            result2 = debrid.resolve_cloud_download_url({
+                "debrid_type": "TB",
+                "torrent_id": "123",
+                "file_id": "456",
+            })
+            assert result2 == "https://tb.example.com/Movie.mkv"
+            assert mock_client.create_download_link.call_count == 1

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -1,0 +1,216 @@
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from lib.download_manager import DownloadManager, DownloadEntry
+
+
+class TestDownloadManager:
+    def setup_method(self):
+        DownloadManager().clear()
+
+    def test_register_creates_entry(self):
+        manager = DownloadManager()
+        entry = manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+
+        assert entry.name == "test.mp4"
+        assert entry.dest_path == "/downloads/test.mp4"
+        assert entry.url == "https://example.com/test.mp4"
+        assert entry.status == "downloading"
+        assert entry.progress == 0
+        assert entry.id == "/downloads/test.mp4"
+
+    def test_register_duplicate_rejects_second_download(self):
+        manager = DownloadManager()
+        manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+
+        result = manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+
+        assert result is None
+        assert len(manager.registry) == 1
+
+    def test_register_duplicate_allows_after_completed(self):
+        manager = DownloadManager()
+        manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+        manager.set_status("/downloads/test.mp4", "completed")
+
+        result = manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+
+        assert result is not None
+        assert result.status == "downloading"
+
+    def test_update_progress_updates_fields(self):
+        manager = DownloadManager()
+        manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+
+        manager.update_progress(
+            "/downloads/test.mp4",
+            downloaded=5_000_000,
+            speed=1_000_000,
+            eta=60,
+            progress=50,
+            size=10_000_000,
+        )
+
+        entry = manager.get_entry("/downloads/test.mp4")
+        assert entry.downloaded == 5_000_000
+        assert entry.speed == 1_000_000
+        assert entry.eta == 60
+        assert entry.progress == 50
+        assert entry.size == 10_000_000
+
+    def test_set_status_changes_status(self):
+        manager = DownloadManager()
+        manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+
+        manager.set_status("/downloads/test.mp4", "paused")
+        entry = manager.get_entry("/downloads/test.mp4")
+        assert entry.status == "paused"
+
+    def test_get_entry_missing_returns_none(self):
+        manager = DownloadManager()
+        assert manager.get_entry("/downloads/missing.mp4") is None
+
+    def test_remove_entry_deletes_from_registry(self):
+        manager = DownloadManager()
+        manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+
+        manager.remove_entry("/downloads/test.mp4")
+        assert manager.get_entry("/downloads/test.mp4") is None
+
+    def test_list_entries_returns_all(self):
+        manager = DownloadManager()
+        manager.register(name="a.mp4", dest_path="/downloads/a.mp4", url="https://example.com/a.mp4")
+        manager.register(name="b.mp4", dest_path="/downloads/b.mp4", url="https://example.com/b.mp4")
+
+        entries = manager.list_entries()
+        assert len(entries) == 2
+        assert {e.name for e in entries} == {"a.mp4", "b.mp4"}
+
+    def test_singleton_same_instance(self):
+        manager1 = DownloadManager()
+        manager2 = DownloadManager()
+        assert manager1 is manager2
+
+    def test_update_progress_missing_entry_no_crash(self):
+        manager = DownloadManager()
+        manager.update_progress(
+            "/downloads/missing.mp4",
+            downloaded=1,
+            speed=1,
+            eta=1,
+            progress=1,
+            size=1,
+        )
+        assert manager.get_entry("/downloads/missing.mp4") is None
+
+    def test_set_status_missing_entry_no_crash(self):
+        manager = DownloadManager()
+        manager.set_status("/downloads/missing.mp4", "paused")
+        assert manager.get_entry("/downloads/missing.mp4") is None
+
+    def test_register_with_thread(self):
+        manager = DownloadManager()
+        mock_thread = MagicMock()
+        entry = manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+            thread=mock_thread,
+        )
+        assert entry.thread is mock_thread
+
+    def test_clear_removes_all_entries(self):
+        manager = DownloadManager()
+        manager.register(name="a.mp4", dest_path="/downloads/a.mp4", url="https://example.com/a.mp4")
+        manager.clear()
+        assert manager.list_entries() == []
+
+    def test_concurrent_register_no_exceptions(self):
+        manager = DownloadManager()
+        errors = []
+
+        def worker(i):
+            try:
+                manager.register(
+                    name=f"file{i}.mp4",
+                    dest_path=f"/downloads/file{i}.mp4",
+                    url=f"https://example.com/file{i}.mp4",
+                )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(manager.registry) == 20
+
+    def test_concurrent_update_no_exceptions(self):
+        manager = DownloadManager()
+        manager.register(
+            name="test.mp4",
+            dest_path="/downloads/test.mp4",
+            url="https://example.com/test.mp4",
+        )
+        errors = []
+
+        def worker(i):
+            try:
+                manager.update_progress(
+                    "/downloads/test.mp4",
+                    downloaded=i * 1_000_000,
+                    speed=1_000_000,
+                    eta=60,
+                    progress=i * 5,
+                    size=20_000_000,
+                )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        entry = manager.get_entry("/downloads/test.mp4")
+        assert entry is not None

--- a/tests/unit/test_download_manager_window.py
+++ b/tests/unit/test_download_manager_window.py
@@ -241,7 +241,7 @@ class TestDownloadManagerWindow:
 
         meta = {"title": "Completed Movie", "status": "completed", "progress": 100, "url": "https://example.com/movie.mkv"}
         with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
-             patch("lib.gui.download_manager_window.os.listdir", return_value=["movie.mkv.jacktook.json"]), \
+             patch("lib.gui.download_manager_window.os.walk", return_value=[("/dl", [], ["movie.mkv.jacktook.json"])]), \
              patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
              patch("lib.gui.download_manager_window._get_setting", return_value="/dl"), \
              patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
@@ -261,7 +261,7 @@ class TestDownloadManagerWindow:
 
         meta = {"title": "Cancelled File", "status": "cancelled", "progress": 30, "url": "https://example.com/cancel.mkv"}
         with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
-             patch("lib.gui.download_manager_window.os.listdir", return_value=["cancel.mkv.jacktook.json"]), \
+             patch("lib.gui.download_manager_window.os.walk", return_value=[("/dl", [], ["cancel.mkv.jacktook.json"])]), \
              patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
              patch("lib.gui.download_manager_window._get_setting", return_value="/dl"), \
              patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
@@ -284,7 +284,7 @@ class TestDownloadManagerWindow:
 
         meta = {"title": "Existing", "status": "completed", "progress": 100, "url": "https://example.com/existing.mkv"}
         with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
-             patch("lib.gui.download_manager_window.os.listdir", return_value=["existing.mkv.jacktook.json"]), \
+             patch("lib.gui.download_manager_window.os.walk", return_value=[("/dl", [], ["existing.mkv.jacktook.json"])]), \
              patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
              patch("lib.gui.download_manager_window._get_setting", return_value=download_dir), \
              patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):

--- a/tests/unit/test_download_manager_window.py
+++ b/tests/unit/test_download_manager_window.py
@@ -240,11 +240,12 @@ class TestDownloadManagerWindow:
         window.setProperty = MagicMock()
 
         meta = {"title": "Completed Movie", "status": "completed", "progress": 100, "url": "https://example.com/movie.mkv"}
-        with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
-             patch("lib.gui.download_manager_window.os.walk", return_value=[("/dl", [], ["movie.mkv.jacktook.json"])]), \
+        with patch("lib.gui.download_manager_window.xbmcvfs") as mock_vfs, \
              patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
              patch("lib.gui.download_manager_window._get_setting", return_value="/dl"), \
              patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
+            mock_vfs.exists.return_value = True
+            mock_vfs.listdir.return_value = ([], ["movie.mkv.jacktook.json"])
             window._sync_from_disk()
 
         manager = DownloadManager()
@@ -260,11 +261,12 @@ class TestDownloadManagerWindow:
         window.setProperty = MagicMock()
 
         meta = {"title": "Cancelled File", "status": "cancelled", "progress": 30, "url": "https://example.com/cancel.mkv"}
-        with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
-             patch("lib.gui.download_manager_window.os.walk", return_value=[("/dl", [], ["cancel.mkv.jacktook.json"])]), \
+        with patch("lib.gui.download_manager_window.xbmcvfs") as mock_vfs, \
              patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
              patch("lib.gui.download_manager_window._get_setting", return_value="/dl"), \
              patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
+            mock_vfs.exists.return_value = True
+            mock_vfs.listdir.return_value = ([], ["cancel.mkv.jacktook.json"])
             window._sync_from_disk()
 
         manager = DownloadManager()
@@ -283,11 +285,12 @@ class TestDownloadManagerWindow:
         window.setProperty = MagicMock()
 
         meta = {"title": "Existing", "status": "completed", "progress": 100, "url": "https://example.com/existing.mkv"}
-        with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
-             patch("lib.gui.download_manager_window.os.walk", return_value=[("/dl", [], ["existing.mkv.jacktook.json"])]), \
+        with patch("lib.gui.download_manager_window.xbmcvfs") as mock_vfs, \
              patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
              patch("lib.gui.download_manager_window._get_setting", return_value=download_dir), \
              patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
+            mock_vfs.exists.return_value = True
+            mock_vfs.listdir.return_value = ([], ["existing.mkv.jacktook.json"])
             window._sync_from_disk()
 
         # Should still be only 1 entry, not duplicated

--- a/tests/unit/test_download_manager_window.py
+++ b/tests/unit/test_download_manager_window.py
@@ -1,0 +1,294 @@
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.download_manager import DownloadManager
+from lib.gui.download_manager_window import DownloadManagerWindow
+
+
+class TestDownloadManagerWindow:
+    def setup_method(self):
+        DownloadManager().clear()
+
+    def test_on_init_sets_empty_message_when_no_entries(self):
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+        window.getControl = MagicMock(return_value=MagicMock())
+
+        window.onInit()
+
+        window.setProperty.assert_any_call("downloads_empty", "true")
+        assert isinstance(window._poll_thread, threading.Thread)
+
+    def test_on_init_starts_polling_thread(self):
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+        window.getControl = MagicMock(return_value=MagicMock())
+        window._monitor = MagicMock()
+        window._monitor.abortRequested.return_value = False
+
+        with patch("lib.gui.download_manager_window.xbmc.sleep") as mock_sleep:
+            call_count = [0]
+
+            def sleep_side_effect(ms):
+                call_count[0] += 1
+                if call_count[0] >= 1:
+                    window._closed = True
+
+            mock_sleep.side_effect = sleep_side_effect
+            window.onInit()
+            window._poll_thread.join(timeout=1)
+
+        assert call_count[0] >= 1
+
+    def test_rebuild_list_sets_empty_when_no_entries(self):
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+        mock_list = MagicMock()
+        window.getControl = MagicMock(return_value=mock_list)
+
+        window._rebuild_list()
+
+        window.setProperty.assert_any_call("downloads_empty", "true")
+        mock_list.reset.assert_called_once()
+
+    def test_rebuild_list_adds_items_for_entries(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+        manager.register(name="b.mkv", dest_path="/dl/b.mkv", url="https://example.com/b.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+        mock_list = MagicMock()
+        window.getControl = MagicMock(return_value=mock_list)
+
+        window._rebuild_list()
+
+        assert mock_list.addItem.call_count == 2
+        window.setProperty.assert_any_call("downloads_empty", "false")
+
+    def test_rebuild_list_preserves_focus_position(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+        manager.register(name="b.mkv", dest_path="/dl/b.mkv", url="https://example.com/b.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+        mock_list = MagicMock()
+        mock_list.getSelectedPosition.return_value = 1
+        mock_list.size.return_value = 2
+        window.getControl = MagicMock(return_value=mock_list)
+
+        window._rebuild_list()
+
+        mock_list.reset.assert_called_once()
+        assert mock_list.addItem.call_count == 2
+        mock_list.selectItem.assert_called_once_with(1)
+
+    def test_rebuild_list_does_not_select_out_of_range(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+        mock_list = MagicMock()
+        mock_list.getSelectedPosition.return_value = 5
+        mock_list.size.return_value = 1
+        window.getControl = MagicMock(return_value=mock_list)
+
+        window._rebuild_list()
+
+        mock_list.selectItem.assert_not_called()
+
+    def test_on_click_pause_sets_cancel_flag(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        mock_list = MagicMock()
+        mock_list.getSelectedItem.return_value.getProperty.return_value = "/dl/a.mkv"
+        window.getControl = MagicMock(return_value=mock_list)
+        window._rebuild_list = MagicMock()
+
+        window.onClick(14003)  # Pause
+
+        entry = manager.get_entry("/dl/a.mkv")
+        assert entry.cancel_flag is True
+
+    def test_on_click_pause_passes_refresh_false(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        mock_list = MagicMock()
+        mock_list.getSelectedItem.return_value.getProperty.return_value = "/dl/a.mkv"
+        window.getControl = MagicMock(return_value=mock_list)
+        window._rebuild_list = MagicMock()
+
+        with patch("lib.gui.download_manager_window.handle_pause_download") as mock_handle_pause:
+            window.onClick(14003)  # Pause
+            mock_handle_pause.assert_called_once()
+            assert mock_handle_pause.call_args.kwargs.get("refresh") is False
+
+    def test_on_click_resume_starts_download(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+        manager.set_status("/dl/a.mkv", "paused")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        mock_list = MagicMock()
+        mock_list.getSelectedItem.return_value.getProperty.return_value = "/dl/a.mkv"
+        window.getControl = MagicMock(return_value=mock_list)
+        window._rebuild_list = MagicMock()
+
+        with patch("lib.gui.download_manager_window.Downloader") as mock_dl:
+            window.onClick(14004)  # Resume
+            mock_dl.assert_called_once()
+            mock_dl.return_value.run.assert_called_once()
+
+    def test_on_click_cancel_sets_status_cancelled(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        mock_list = MagicMock()
+        mock_list.getSelectedItem.return_value.getProperty.return_value = "/dl/a.mkv"
+        window.getControl = MagicMock(return_value=mock_list)
+        window._rebuild_list = MagicMock()
+
+        window.onClick(14005)  # Cancel
+
+        entry = manager.get_entry("/dl/a.mkv")
+        assert entry.status == "cancelled"
+
+    def test_on_click_delete_removes_entry(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        mock_list = MagicMock()
+        mock_list.getSelectedItem.return_value.getProperty.return_value = "/dl/a.mkv"
+        window.getControl = MagicMock(return_value=mock_list)
+        window._rebuild_list = MagicMock()
+
+        with patch("lib.gui.download_manager_window.xbmcvfs") as mock_vfs:
+            window.onClick(14006)  # Delete
+            assert manager.get_entry("/dl/a.mkv") is None
+
+    def test_on_click_clear_completed_removes_only_completed(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+        manager.register(name="b.mkv", dest_path="/dl/b.mkv", url="https://example.com/b.mkv")
+        manager.set_status("/dl/b.mkv", "completed")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window._rebuild_list = MagicMock()
+
+        window.onClick(14007)  # Clear Completed
+
+        assert manager.get_entry("/dl/a.mkv") is not None
+        assert manager.get_entry("/dl/b.mkv") is None
+
+    def test_poll_loop_updates_selected_properties(self):
+        manager = DownloadManager()
+        manager.register(name="a.mkv", dest_path="/dl/a.mkv", url="https://example.com/a.mkv")
+        manager.update_progress("/dl/a.mkv", downloaded=50, speed=1000, eta=60, progress=50, size=100)
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+        mock_selected_item = MagicMock()
+        mock_selected_item.getProperty.return_value = "/dl/a.mkv"
+        mock_list = MagicMock()
+        mock_list.getSelectedItem.return_value = mock_selected_item
+        window.getControl = MagicMock(return_value=mock_list)
+        window._focused_item_id = "/dl/a.mkv"
+        window._monitor = MagicMock()
+        window._monitor.abortRequested.return_value = False
+
+        with patch("lib.gui.download_manager_window.xbmc.sleep") as mock_sleep:
+            call_count = [0]
+
+            def sleep_side_effect(ms):
+                call_count[0] += 1
+                if call_count[0] >= 1:
+                    window._closed = True
+
+            mock_sleep.side_effect = sleep_side_effect
+            window._poll_loop()
+
+        window.setProperty.assert_any_call("selected_progress", "50")
+        window.setProperty.assert_any_call("selected_speed", "1e+03 B/s")
+        window.setProperty.assert_any_call("selected_eta", "1m 0s")
+        window.setProperty.assert_any_call("selected_size", "100 B")
+
+    def test_on_action_sets_closed_flag(self):
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window._closed = False
+        mock_action = MagicMock()
+        mock_action.getId.return_value = 10  # ACTION_PREVIOUS_MENU
+
+        window.onAction(mock_action)
+
+        assert window._closed is True
+
+    def test_sync_from_disk_registers_existing_downloads(self):
+        """_sync_from_disk should register downloads found in .jacktook.json files."""
+        DownloadManager().clear()
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+
+        meta = {"title": "Completed Movie", "status": "completed", "progress": 100, "url": "https://example.com/movie.mkv"}
+        with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
+             patch("lib.gui.download_manager_window.os.listdir", return_value=["movie.mkv.jacktook.json"]), \
+             patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
+             patch("lib.gui.download_manager_window._get_setting", return_value="/dl"), \
+             patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
+            window._sync_from_disk()
+
+        manager = DownloadManager()
+        entries = manager.list_entries()
+        assert len(entries) == 1
+        assert entries[0].status == "completed"
+        assert entries[0].progress == 100
+
+    def test_sync_from_disk_skips_cancelled_downloads(self):
+        """_sync_from_disk should skip entries with cancelled status."""
+        DownloadManager().clear()
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+
+        meta = {"title": "Cancelled File", "status": "cancelled", "progress": 30, "url": "https://example.com/cancel.mkv"}
+        with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
+             patch("lib.gui.download_manager_window.os.listdir", return_value=["cancel.mkv.jacktook.json"]), \
+             patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
+             patch("lib.gui.download_manager_window._get_setting", return_value="/dl"), \
+             patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
+            window._sync_from_disk()
+
+        manager = DownloadManager()
+        assert len(manager.list_entries()) == 0
+
+    def test_sync_from_disk_skips_already_registered(self):
+        """_sync_from_disk should not re-register entries already in the registry."""
+        DownloadManager().clear()
+        download_dir = "/dl"
+        manager = DownloadManager()
+        # Pre-register an entry at the path that _sync_from_disk would compute
+        existing_dest = f"{download_dir}/existing.mkv"
+        manager.register(name="Existing", dest_path=existing_dest, url="https://example.com/existing.mkv")
+
+        window = DownloadManagerWindow("download_manager.xml", "")
+        window.setProperty = MagicMock()
+
+        meta = {"title": "Existing", "status": "completed", "progress": 100, "url": "https://example.com/existing.mkv"}
+        with patch("lib.gui.download_manager_window.os.path.isdir", return_value=True), \
+             patch("lib.gui.download_manager_window.os.listdir", return_value=["existing.mkv.jacktook.json"]), \
+             patch("lib.gui.download_manager_window.get_download_metadata", return_value=meta), \
+             patch("lib.gui.download_manager_window._get_setting", return_value=download_dir), \
+             patch("lib.gui.download_manager_window._translatePath", side_effect=lambda x: x):
+            window._sync_from_disk()
+
+        # Should still be only 1 entry, not duplicated
+        assert len(manager.list_entries()) == 1

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -294,3 +294,277 @@ def test_download_video_uses_organized_destination():
     mock_handle.assert_called_once_with(
         {"destination": "/downloads/Movies", "file_name": "Movie", "url": "https://example.com/Movie.mkv"}
     )
+
+
+# --- Tests for Downloader registry integration ---
+
+def test_downloader_accepts_registry_id():
+    downloader = _load_downloader_module()
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    assert dl.registry_id == "/downloads/Movie.mkv"
+
+
+def test_downloader_registry_id_defaults_to_none():
+    downloader = _load_downloader_module()
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+    )
+    assert dl.registry_id is None
+
+
+def test_start_download_updates_registry_per_chunk():
+    downloader = _load_downloader_module()
+
+    from lib.download_manager import DownloadManager
+    manager = DownloadManager()
+    manager.clear()
+    manager.register(name="Movie.mkv", dest_path="/downloads/Movie.mkv", url="https://example.com/Movie.mkv")
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    dl.file_size = 3 * 1024 * 1024  # 3 MB
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = [b"x" * (1024 * 1024), b"x" * (1024 * 1024), b"x" * (1024 * 1024), b""]
+    mock_response.headers = {"Content-Length": str(3 * 1024 * 1024)}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dl.destination = tmpdir
+        dl.dest_path = os.path.join(tmpdir, "Movie.mkv")
+        dl.temp_path = dl.dest_path + ".part"
+        dl.meta_path = dl.dest_path + ".jacktook.json"
+
+        with patch.object(downloader, "KodiProgressHandler") as mock_handler_cls, patch.object(
+            downloader, "urlopen", return_value=mock_response
+        ), patch.object(downloader.xbmcvfs, "exists", return_value=False), patch.object(
+            downloader.xbmcvfs, "rename"
+        ):
+            mock_handler = MagicMock()
+            mock_handler_cls.return_value = mock_handler
+            mock_handler.cancelled.return_value = False
+            dl.monitor = MagicMock()
+            dl.monitor.abortRequested.return_value = False
+            dl._start_download()
+
+    entry = manager.get_entry("/downloads/Movie.mkv")
+    assert entry is not None
+    assert entry.progress == 100
+    assert entry.downloaded == 3 * 1024 * 1024
+    assert entry.status == "completed"
+
+
+def test_start_download_sets_registry_status_paused_on_cancel():
+    downloader = _load_downloader_module()
+
+    from lib.download_manager import DownloadManager
+    manager = DownloadManager()
+    manager.clear()
+    manager.register(name="Movie.mkv", dest_path="/downloads/Movie.mkv", url="https://example.com/Movie.mkv")
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    dl.file_size = 10 * 1024 * 1024  # 10 MB
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = [b"x" * (1024 * 1024), b"x" * (1024 * 1024), b""]
+    mock_response.headers = {"Content-Length": str(10 * 1024 * 1024)}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dl.destination = tmpdir
+        dl.dest_path = os.path.join(tmpdir, "Movie.mkv")
+        dl.temp_path = dl.dest_path + ".part"
+        dl.meta_path = dl.dest_path + ".jacktook.json"
+
+        with patch.object(downloader, "KodiProgressHandler") as mock_handler_cls, patch.object(
+            downloader, "urlopen", return_value=mock_response
+        ), patch.object(downloader.xbmcvfs, "exists", return_value=False), patch.object(
+            downloader.xbmcvfs, "rename"
+        ):
+            mock_handler = MagicMock()
+            mock_handler_cls.return_value = mock_handler
+            # Cancel after first chunk
+            call_count = [0]
+
+            def cancelled_side_effect():
+                call_count[0] += 1
+                return call_count[0] > 1
+
+            mock_handler.cancelled.side_effect = cancelled_side_effect
+            dl.monitor = MagicMock()
+            dl.monitor.abortRequested.return_value = False
+            dl._start_download()
+
+    entry = manager.get_entry("/downloads/Movie.mkv")
+    assert entry is not None
+    assert entry.status == "paused"
+
+
+def test_start_download_respects_registry_cancel_flag():
+    downloader = _load_downloader_module()
+
+    from lib.download_manager import DownloadManager
+    manager = DownloadManager()
+    manager.clear()
+    entry = manager.register(name="Movie.mkv", dest_path="/downloads/Movie.mkv", url="https://example.com/Movie.mkv")
+    entry.cancel_flag = True
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    dl.file_size = 10 * 1024 * 1024
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = [b"x" * (1024 * 1024), b""]
+    mock_response.headers = {"Content-Length": str(10 * 1024 * 1024)}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dl.destination = tmpdir
+        dl.dest_path = os.path.join(tmpdir, "Movie.mkv")
+        dl.temp_path = dl.dest_path + ".part"
+        dl.meta_path = dl.dest_path + ".jacktook.json"
+
+        with patch.object(downloader, "KodiProgressHandler") as mock_handler_cls, patch.object(
+            downloader, "urlopen", return_value=mock_response
+        ), patch.object(downloader.xbmcvfs, "exists", return_value=False), patch.object(
+            downloader.xbmcvfs, "rename"
+        ):
+            mock_handler = MagicMock()
+            mock_handler_cls.return_value = mock_handler
+            mock_handler.cancelled.return_value = False
+            dl.monitor = MagicMock()
+            dl.monitor.abortRequested.return_value = False
+            dl._start_download()
+
+    entry = manager.get_entry("/downloads/Movie.mkv")
+    assert entry is not None
+    assert entry.status == "paused"
+
+
+def test_start_download_sets_registry_status_error_on_exception():
+    downloader = _load_downloader_module()
+
+    from lib.download_manager import DownloadManager
+    manager = DownloadManager()
+    manager.clear()
+    manager.register(name="Movie.mkv", dest_path="/downloads/Movie.mkv", url="https://example.com/Movie.mkv")
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    dl.file_size = 10 * 1024 * 1024
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dl.destination = tmpdir
+        dl.dest_path = os.path.join(tmpdir, "Movie.mkv")
+        dl.temp_path = dl.dest_path + ".part"
+        dl.meta_path = dl.dest_path + ".jacktook.json"
+
+        with patch.object(downloader, "KodiProgressHandler") as mock_handler_cls, patch.object(
+            downloader, "urlopen", side_effect=Exception("network error")
+        ), patch.object(downloader.xbmcvfs, "exists", return_value=False):
+            mock_handler = MagicMock()
+            mock_handler_cls.return_value = mock_handler
+            dl._start_download()
+
+    entry = manager.get_entry("/downloads/Movie.mkv")
+    assert entry is not None
+    assert entry.status == "error"
+
+
+def test_update_registry_calculates_speed_and_eta():
+    downloader = _load_downloader_module()
+
+    from lib.download_manager import DownloadManager
+    manager = DownloadManager()
+    manager.clear()
+    manager.register(name="Movie.mkv", dest_path="/downloads/Movie.mkv", url="https://example.com/Movie.mkv")
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    dl.file_size = 10_000_000
+    dl._start_time = 0
+
+    with patch.object(downloader, "time") as mock_time:
+        mock_time.time.return_value = 5
+        dl._update_registry(downloaded=5_000_000, percent=50)
+
+    entry = manager.get_entry("/downloads/Movie.mkv")
+    assert entry.speed == 1_000_000
+    assert entry.eta == 5
+
+
+def test_update_registry_speed_zero_when_no_start_time():
+    downloader = _load_downloader_module()
+
+    from lib.download_manager import DownloadManager
+    manager = DownloadManager()
+    manager.clear()
+    manager.register(name="Movie.mkv", dest_path="/downloads/Movie.mkv", url="https://example.com/Movie.mkv")
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    dl.file_size = 10_000_000
+    dl._start_time = None
+
+    dl._update_registry(downloaded=5_000_000, percent=50)
+
+    entry = manager.get_entry("/downloads/Movie.mkv")
+    assert entry.speed == 0
+    assert entry.eta == 0
+
+
+def test_update_registry_eta_zero_when_download_complete():
+    downloader = _load_downloader_module()
+
+    from lib.download_manager import DownloadManager
+    manager = DownloadManager()
+    manager.clear()
+    manager.register(name="Movie.mkv", dest_path="/downloads/Movie.mkv", url="https://example.com/Movie.mkv")
+
+    dl = downloader.Downloader(
+        url="https://example.com/Movie.mkv",
+        destination="/downloads",
+        name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
+    )
+    dl.file_size = 10_000_000
+    dl._start_time = 0
+
+    with patch.object(downloader, "time") as mock_time:
+        mock_time.time.return_value = 5
+        dl._update_registry(downloaded=10_000_000, percent=100)
+
+    entry = manager.get_entry("/downloads/Movie.mkv")
+    assert entry.speed == 2_000_000
+    assert entry.eta == 0

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -52,7 +52,12 @@ def test_handle_download_file_passes_url_to_normalizer():
         downloader, "normalize_file_name", return_value="Movie.mkv"
     ) as normalize_file_name, patch.object(
         downloader, "Downloader", return_value=downloader_instance
-    ) as downloader_cls, patch.object(downloader.cancel_flag_cache, "set") as cache_set:
+    ) as downloader_cls, patch.object(
+        downloader, "DownloadManager"
+    ) as mock_manager_cls, patch.object(downloader.cancel_flag_cache, "set") as cache_set:
+        mock_manager = MagicMock()
+        mock_manager.register.return_value = MagicMock()
+        mock_manager_cls.return_value = mock_manager
         downloader.handle_download_file(
             {
                 "destination": "/downloads",
@@ -66,6 +71,7 @@ def test_handle_download_file_passes_url_to_normalizer():
         url="https://example.com/Movie.mkv",
         destination="/downloads",
         name="Movie.mkv",
+        registry_id="/downloads/Movie.mkv",
     )
     cache_set.assert_called_once_with("/downloads/Movie.mkv", False)
     downloader_instance.run.assert_called_once_with()

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -186,7 +186,9 @@ def test_get_download_metadata_reads_existing_json():
         with open(meta_path, "w") as f:
             json.dump({"status": "paused", "progress": 42, "title": "Video"}, f)
 
-        result = downloader.get_download_metadata(path)
+        with patch.object(downloader.xbmcvfs, "exists", side_effect=lambda p: os.path.exists(p)), \
+             patch.object(downloader, "open_file", side_effect=lambda p, m="r": open(p, m)):
+            result = downloader.get_download_metadata(path)
 
     assert result == {"status": "paused", "progress": 42, "title": "Video"}
 
@@ -202,7 +204,9 @@ def test_handle_pause_download_sets_cancel_flag_and_metadata():
         with open(meta_path, "w") as f:
             json.dump({"status": "downloading", "progress": 50, "title": "Video"}, f)
 
-        with patch.object(downloader.cancel_flag_cache, "set") as cache_set:
+        with patch.object(downloader.cancel_flag_cache, "set") as cache_set, \
+             patch.object(downloader.xbmcvfs, "exists", side_effect=lambda p: os.path.exists(p)), \
+             patch.object(downloader, "open_file", side_effect=lambda p, m="r": open(p, m)):
             downloader.handle_pause_download({"file_path": json.dumps(path)})
 
         cache_set.assert_called_once_with(path, True)
@@ -227,9 +231,10 @@ def test_resume_download_clears_flag_and_starts_downloader():
             )
 
         downloader_instance = MagicMock()
-        with patch.object(downloader.cancel_flag_cache, "set") as cache_set, patch.object(
-            downloader, "Downloader", return_value=downloader_instance
-        ) as downloader_cls:
+        with patch.object(downloader.cancel_flag_cache, "set") as cache_set, \
+             patch.object(downloader, "Downloader", return_value=downloader_instance) as downloader_cls, \
+             patch.object(downloader.xbmcvfs, "exists", side_effect=lambda p: os.path.exists(p)), \
+             patch.object(downloader, "open_file", side_effect=lambda p, m="r": open(p, m)):
             downloader.resume_download({"file_path": json.dumps(path)})
 
         cache_set.assert_called_once_with(path, False)

--- a/tests/unit/test_source_select_download.py
+++ b/tests/unit/test_source_select_download.py
@@ -26,19 +26,22 @@ def test_download_file_uses_episode_filename_when_tv_data_is_present():
         "title": "Game of Thrones",
         "url": "https://example.com/files/game.of.thrones.mkv",
         "tv_data": {"season": "1", "episode": "1"},
+        "mode": "movie",
     }
 
     with patch.object(
         source_select_module.SourceSelect,
         "_ensure_playback_info",
         return_value=playback_info,
-    ), patch.object(source_select_module, "get_setting", return_value="/downloads"), patch.object(
-        source_select_module, "translatePath", return_value="/downloads"
-    ), patch.object(source_select_module, "action_url_run", return_value="builtin") as action_url_run, patch.object(
+    ), patch("lib.downloader.get_destination_path", return_value="/downloads") as mock_get_dest, patch.object(source_select_module, "action_url_run", return_value="builtin") as action_url_run, patch.object(
         source_select_module.xbmc, "executebuiltin"
     ) as executebuiltin:
         source_select._download_file(selected_source)
 
+    mock_get_dest.assert_called_once()
+    dest_call_data = mock_get_dest.call_args[0][0]
+    assert dest_call_data["title"] == "Game of Thrones"
+    assert dest_call_data["mode"] == "movies"
     action_url_run.assert_called_once_with(
         "handle_download_file",
         file_name="Game of Thrones - S01E01",
@@ -61,19 +64,22 @@ def test_download_file_uses_year_for_movie_filename():
     playback_info = {
         "title": "Project Hail Mary",
         "url": "https://example.com/files/project.hail.mary.mkv",
+        "mode": "movie",
     }
 
     with patch.object(
         source_select_module.SourceSelect,
         "_ensure_playback_info",
         return_value=playback_info,
-    ), patch.object(source_select_module, "get_setting", return_value="/downloads"), patch.object(
-        source_select_module, "translatePath", return_value="/downloads"
-    ), patch.object(source_select_module, "action_url_run", return_value="builtin") as action_url_run, patch.object(
+    ), patch("lib.downloader.get_destination_path", return_value="/downloads") as mock_get_dest, patch.object(source_select_module, "action_url_run", return_value="builtin") as action_url_run, patch.object(
         source_select_module.xbmc, "executebuiltin"
     ) as executebuiltin:
         source_select._download_file(selected_source)
 
+    mock_get_dest.assert_called_once()
+    dest_call_data = mock_get_dest.call_args[0][0]
+    assert dest_call_data["title"] == "Project Hail Mary"
+    assert dest_call_data["mode"] == "movies"
     action_url_run.assert_called_once_with(
         "handle_download_file",
         file_name="Project Hail Mary (2025)",


### PR DESCRIPTION
Closes #189

## Summary
- add a dedicated Download Manager window for active download monitoring and controls
- add a Downloads submenu with My Downloads and Download Manager entries
- make completed local downloads browsable and playable from My Downloads
- add coverage for manager, window, downloader, and cloud download flows

## Changes
| File | Change |
|------|--------|
| `lib/download_manager.py` | add in-memory download registry and entry model |
| `lib/downloader.py` | add cloud/local download workflow, downloads viewer integration, and playback routing |
| `lib/gui/download_manager_window.py` | add custom download manager dialog with pause/resume/cancel/delete actions |
| `lib/nav/debrid.py` | add cloud download actions |
| `lib/navigation.py` | wire Downloads submenu and manager entry |
| `lib/router.py` | add downloads routes |
| `resources/skins/Default/1080i/download_manager.xml` | add download manager skin |
| `tests/unit/test_cloud_download.py` | add cloud download resolution coverage |
| `tests/unit/test_download_manager.py` | add manager registry coverage |
| `tests/unit/test_download_manager_window.py` | add window behavior coverage |
| `tests/unit/test_downloader.py` | add downloader behavior coverage |

## Test Plan
- [x] `python3 -m pytest -q`
- [x] Verified keyboard navigation wiring for manager buttons
- [x] Verified paused downloads resume without reopening the modal progress dialog