### PR TITLE
fix: forward episode metadata to Elementum

### DIFF
--- a/lib/utils/player/utils.py
+++ b/lib/utils/player/utils.py
@@ -117,7 +117,7 @@ def get_torrent_url_for_client(
     if torrent_client in [Players.TORREST]:
         return get_torrest_url(magnet, url)
     elif torrent_client in [Players.ELEMENTUM]:
-        return get_elementum_url(magnet, url, mode, ids)
+        return get_elementum_url(magnet, url, mode, ids, data=data)
     elif torrent_client in [Players.JACKTORR]:
         jacktorr_data = dict(data or {})
         jacktorr_data.pop("file_idx", None)
@@ -148,6 +148,7 @@ def get_elementum_url(
     url: str,
     mode: str,
     ids: Any,
+    data: Optional[Dict[str, Any]] = None,
 ) -> Optional[str]:
     if not is_elementum_addon():
         if Dialog().yesno(
@@ -162,13 +163,30 @@ def get_elementum_url(
             return None
 
     tmdb_id = ids.get("tmdb_id", "") if isinstance(ids, dict) else ""
-
     uri = url or magnet
 
-    if uri:
-        return f"plugin://plugin.video.elementum/play?uri={quote(uri)}&type={mode}&tmdb={tmdb_id}"
-    else:
+    if not uri:
         raise TorrentException("No magnet or url found for Elementum playback")
+
+    episode_params = ""
+    tv_data = (data or {}).get("tv_data")
+    if mode == "tv" and isinstance(tv_data, dict):
+        season = tv_data.get("season")
+        episode = tv_data.get("episode")
+        if all(
+            not isinstance(value, bool) and str(value).isdigit()
+            for value in (tmdb_id, season, episode)
+        ):
+            episode_params = (
+                f"&show={quote(str(tmdb_id))}"
+                f"&season={quote(str(season))}"
+                f"&episode={quote(str(episode))}"
+            )
+
+    return (
+        f"plugin://plugin.video.elementum/play?uri={quote(uri)}"
+        f"&type={mode}&tmdb={tmdb_id}{episode_params}"
+    )
 
 
 def get_jacktorr_url(magnet: str, url: str, data: Optional[Dict[str, Any]] = None) -> Optional[str]:

--- a/tests/unit/test_elementum_episode_selection.py
+++ b/tests/unit/test_elementum_episode_selection.py
@@ -1,0 +1,86 @@
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+
+def _query(url: str):
+    return parse_qs(urlparse(url).query)
+
+
+def test_elementum_client_forwards_episode_metadata():
+    from lib.utils.general.utils import Players
+    from lib.utils.player import utils
+
+    ids = {"tmdb_id": "2190"}
+    data = {
+        "mode": "tv",
+        "ids": ids,
+        "tv_data": {"season": 4, "episode": 3},
+    }
+
+    with patch.object(utils, "is_elementum_addon", return_value=True):
+        url = utils.get_torrent_url_for_client(
+            "magnet:?xt=urn:btih:EPISODEHASH",
+            "",
+            "tv",
+            ids,
+            client=Players.ELEMENTUM,
+            data=data,
+        )
+
+    query = _query(url)
+    assert query["tmdb"] == ["2190"]
+    assert query["show"] == ["2190"]
+    assert query["season"] == ["4"]
+    assert query["episode"] == ["3"]
+
+
+def test_elementum_movie_omits_episode_metadata():
+    from lib.utils.player import utils
+
+    with patch.object(utils, "is_elementum_addon", return_value=True):
+        url = utils.get_elementum_url(
+            "magnet:?xt=urn:btih:MOVIEHASH",
+            "",
+            "movie",
+            {"tmdb_id": "100"},
+            data={"tv_data": {"season": 4, "episode": 3}},
+        )
+
+    query = _query(url)
+    assert query["tmdb"] == ["100"]
+    assert "show" not in query
+    assert "season" not in query
+    assert "episode" not in query
+
+
+@pytest.mark.parametrize(
+    ("ids", "data"),
+    [
+        ({"tmdb_id": "2190"}, {}),
+        ({"tmdb_id": "2190"}, {"tv_data": {}}),
+        ({"tmdb_id": "2190"}, {"tv_data": {"season": 4}}),
+        ({"tmdb_id": "2190"}, {"tv_data": {"episode": 3}}),
+        ({"tmdb_id": "2190"}, {"tv_data": {"season": "four", "episode": 3}}),
+        ({"tmdb_id": "2190"}, {"tv_data": {"season": True, "episode": 3}}),
+        ({"tmdb_id": "show"}, {"tv_data": {"season": 4, "episode": 3}}),
+        ({"tmdb_id": "2190"}, {"tv_data": [4, 3]}),
+    ],
+)
+def test_elementum_omits_invalid_or_incomplete_episode_metadata(ids, data):
+    from lib.utils.player import utils
+
+    with patch.object(utils, "is_elementum_addon", return_value=True):
+        url = utils.get_elementum_url(
+            "magnet:?xt=urn:btih:EPISODEHASH",
+            "",
+            "tv",
+            ids,
+            data=data,
+        )
+
+    query = _query(url)
+    assert "show" not in query
+    assert "season" not in query
+    assert "episode" not in query


### PR DESCRIPTION
## Summary

- forward Jacktook's existing playback metadata to the Elementum URL builder
- add Elementum's supported `show`, `season`, and `episode` parameters for valid TV episode metadata
- keep movie playback and incomplete/invalid metadata behavior unchanged
- add focused unit coverage for episode forwarding and fallback behavior

## Problem

When a user selects an episode and then chooses a multi-file season/show pack, Jacktook currently calls Elementum's `/play` route with only `uri`, `type`, and `tmdb`. The `tv_data` already available in Jacktook is discarded on the Elementum path.

Elementum supports `show`, `season`, and `episode` on `/play` and uses them for smart file matching. Without those parameters, Elementum opens a second file-selection dialog. The same missing context can also make next-episode playback return to the pack file list instead of selecting the requested episode.

## Scope

The change is isolated to the `Players.ELEMENTUM` branch. Torrest, Jacktorr, debrid providers, and existing movie URLs are untouched. If the show ID, season, or episode is missing or invalid, the extra parameters are omitted so Elementum keeps its existing manual fallback.

## Testing

- Python syntax validation completed locally
- unit tests added for valid TV metadata, movies, and invalid/incomplete metadata
- manual Kodi/Elementum pack validation pending
