### PR TITLE
fix: select matching movie file in Elementum multi-file torrents

### DIFF
--- a/lib/utils/player/utils.py
+++ b/lib/utils/player/utils.py
@@ -1,3 +1,5 @@
+import re
+import unicodedata
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, quote, urlparse
@@ -34,6 +36,49 @@ from lib.utils.kodi.utils import (
     notification,
     translation,
 )
+
+_ELEMENTUM_MOVIE_FILE_SEPARATOR = r"[\s._'’\-]+"
+_ELEMENTUM_MOVIE_ACCENT_CLASSES = {
+    "a": r"[aàáâäãå]",
+    "c": r"[cç]",
+    "e": r"[eèéêë]",
+    "i": r"[iìíîï]",
+    "n": r"[nñ]",
+    "o": r"[oòóôöõ]",
+    "u": r"[uùúûü]",
+    "y": r"[yýÿ]",
+}
+
+
+def _build_elementum_movie_file_match(title: Any) -> str:
+    """Build a conservative filename regex for Elementum movie torrents.
+
+    Elementum selects the first playable file matching ``file_match`` and falls
+    back to its normal file picker when no file matches. Keep this deliberately
+    strict so collection/trilogy torrents never auto-select from a vague title.
+    """
+    if not isinstance(title, str):
+        return ""
+
+    normalized = title.casefold().replace("œ", "oe").replace("æ", "ae")
+    normalized = unicodedata.normalize("NFKD", normalized)
+    normalized = "".join(
+        char for char in normalized if not unicodedata.combining(char)
+    )
+    tokens = re.findall(r"[a-z0-9]+", normalized)
+
+    # One-word/very short titles are too ambiguous for a first-match strategy.
+    if len(tokens) < 2 or not any(len(token) >= 4 for token in tokens):
+        return ""
+
+    def token_pattern(token: str) -> str:
+        return "".join(
+            _ELEMENTUM_MOVIE_ACCENT_CLASSES.get(char, char) for char in token
+        )
+
+    return _ELEMENTUM_MOVIE_FILE_SEPARATOR.join(
+        token_pattern(token) for token in tokens
+    )
 
 
 def resolve_playback_url(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -191,7 +236,7 @@ def get_elementum_url(
     if not uri:
         raise TorrentException("No magnet or url found for Elementum playback")
 
-    episode_params = ""
+    selection_params = ""
     tv_data = (data or {}).get("tv_data")
     if mode == "tv" and isinstance(tv_data, dict):
         season = tv_data.get("season")
@@ -200,15 +245,19 @@ def get_elementum_url(
             not isinstance(value, bool) and str(value).isdigit()
             for value in (tmdb_id, season, episode)
         ):
-            episode_params = (
+            selection_params = (
                 f"&show={quote(str(tmdb_id))}"
                 f"&season={quote(str(season))}"
                 f"&episode={quote(str(episode))}"
             )
+    elif mode == "movie":
+        file_match = _build_elementum_movie_file_match((data or {}).get("title"))
+        if file_match:
+            selection_params = f"&file_match={quote(file_match)}"
 
     return (
         f"plugin://plugin.video.elementum/play?uri={quote(uri)}"
-        f"&type={mode}&tmdb={tmdb_id}{episode_params}"
+        f"&type={mode}&tmdb={tmdb_id}{selection_params}"
     )
 
 

--- a/lib/utils/player/utils.py
+++ b/lib/utils/player/utils.py
@@ -250,7 +250,7 @@ def get_elementum_url(
                 f"&season={quote(str(season))}"
                 f"&episode={quote(str(episode))}"
             )
-    elif mode == "movie":
+    elif mode in ("movie", "movies"):
         file_match = _build_elementum_movie_file_match((data or {}).get("title"))
         if file_match:
             selection_params = f"&file_match={quote(file_match)}"

--- a/tests/unit/test_elementum_movie_file_selection.py
+++ b/tests/unit/test_elementum_movie_file_selection.py
@@ -15,7 +15,7 @@ def test_elementum_movie_forwards_conservative_file_match():
 
     ids = {"tmdb_id": "4271"}
     data = {
-        "mode": "movie",
+        "mode": "movies",
         "ids": ids,
         "title": "Mais où est donc passée la 7ème compagnie ?",
     }
@@ -24,7 +24,7 @@ def test_elementum_movie_forwards_conservative_file_match():
         url = utils.get_torrent_url_for_client(
             "magnet:?xt=urn:btih:TRILOGYHASH",
             "",
-            "movie",
+            "movies",
             ids,
             client=Players.ELEMENTUM,
             data=data,

--- a/tests/unit/test_elementum_movie_file_selection.py
+++ b/tests/unit/test_elementum_movie_file_selection.py
@@ -1,0 +1,110 @@
+import re
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+
+def _query(url: str):
+    return parse_qs(urlparse(url).query)
+
+
+def test_elementum_movie_forwards_conservative_file_match():
+    from lib.utils.general.utils import Players
+    from lib.utils.player import utils
+
+    ids = {"tmdb_id": "4271"}
+    data = {
+        "mode": "movie",
+        "ids": ids,
+        "title": "Mais où est donc passée la 7ème compagnie ?",
+    }
+
+    with patch.object(utils, "is_elementum_addon", return_value=True):
+        url = utils.get_torrent_url_for_client(
+            "magnet:?xt=urn:btih:TRILOGYHASH",
+            "",
+            "movie",
+            ids,
+            client=Players.ELEMENTUM,
+            data=data,
+        )
+
+    query = _query(url)
+    assert query["tmdb"] == ["4271"]
+    assert "file_match" in query
+
+    file_match = query["file_match"][0]
+    assert re.search(
+        file_match,
+        "Mais.ou.est.donc.passee.la.7eme.compagnie.1973.1080p.mkv",
+        flags=re.IGNORECASE,
+    )
+    assert re.search(
+        file_match,
+        "Mais où est donc passée la 7ème compagnie (1973).mkv",
+        flags=re.IGNORECASE,
+    )
+
+
+def test_elementum_movie_match_does_not_match_other_trilogy_films():
+    from lib.utils.player import utils
+
+    with patch.object(utils, "is_elementum_addon", return_value=True):
+        url = utils.get_elementum_url(
+            "magnet:?xt=urn:btih:TRILOGYHASH",
+            "",
+            "movie",
+            {"tmdb_id": "4271"},
+            data={"title": "Mais où est donc passée la 7ème compagnie ?"},
+        )
+
+    file_match = _query(url)["file_match"][0]
+    assert not re.search(
+        file_match,
+        "On.a.retrouve.la.7eme.compagnie.1975.1080p.mkv",
+        flags=re.IGNORECASE,
+    )
+    assert not re.search(
+        file_match,
+        "La.7eme.compagnie.au.clair.de.lune.1977.1080p.mkv",
+        flags=re.IGNORECASE,
+    )
+
+
+@pytest.mark.parametrize("title", [None, "", "Alien", "It 2", 123])
+def test_elementum_movie_ambiguous_title_keeps_manual_file_picker(title):
+    from lib.utils.player import utils
+
+    with patch.object(utils, "is_elementum_addon", return_value=True):
+        url = utils.get_elementum_url(
+            "magnet:?xt=urn:btih:MOVIEHASH",
+            "",
+            "movie",
+            {"tmdb_id": "100"},
+            data={"title": title},
+        )
+
+    assert "file_match" not in _query(url)
+
+
+def test_elementum_tv_episode_selection_does_not_add_movie_file_match():
+    from lib.utils.player import utils
+
+    with patch.object(utils, "is_elementum_addon", return_value=True):
+        url = utils.get_elementum_url(
+            "magnet:?xt=urn:btih:EPISODEHASH",
+            "",
+            "tv",
+            {"tmdb_id": "2190"},
+            data={
+                "title": "A TV Show",
+                "tv_data": {"season": 4, "episode": 3},
+            },
+        )
+
+    query = _query(url)
+    assert query["show"] == ["2190"]
+    assert query["season"] == ["4"]
+    assert query["episode"] == ["3"]
+    assert "file_match" not in query


### PR DESCRIPTION
## Summary

Avoid Elementum reopening its file picker when a Jacktook movie source is a multi-file torrent (for example, a trilogy/collection torrent) and the requested movie can be matched safely.

## What changes

- Build a conservative, accent-insensitive `file_match` regex from the requested movie title.
- Forward that matcher to Elementum for both Jacktook movie modes: `movie` and the real UI mode `movies`.
- Keep Elementum's normal manual file picker for ambiguous/very short movie titles or when no match is found.
- Leave TV episode/season selection behavior unchanged.

The matcher is intentionally strict because Elementum selects the first matching playable file. This prevents a collection torrent from silently launching a different movie.

## Tests

Added unit coverage for:

- matching the requested movie inside a multi-file trilogy torrent;
- not matching the other two trilogy movies;
- accent/separator variations in filenames;
- ambiguous titles falling back to Elementum's manual picker;
- `movies` mode used by the real Jacktook UI;
- unchanged TV episode selection behavior.

Full unit suite passes locally.

## Real-world validation

Validated on Kodi with Elementum using a torrent containing all three *La 7ème compagnie* movies.

Before the fix, Elementum reopened a second picker with the three files. With this branch, selecting *La 7ème Compagnie au clair de lune* in Jacktook launches the matching file directly without the second picker.