### PR TITLE
fix: replace deprecated datetime.utcnow usage

### DIFF
--- a/lib/clients/trakt/trakt.py
+++ b/lib/clients/trakt/trakt.py
@@ -1,6 +1,6 @@
 import contextlib
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from lib.api.trakt.trakt import TraktAPI, TraktLists, TraktMovies, TraktTV
 from lib.api.trakt.trakt_utils import (
@@ -329,7 +329,7 @@ class TraktClient:
         total_seasons = getattr(show_details, "number_of_seasons", 0) or show_details.get(
             "number_of_seasons", 0
         )
-        today = datetime.utcnow().date()
+        today = datetime.now(timezone.utc).date()
         seasons_payload = []
 
         for season_number in range(1, int(total_seasons) + 1):


### PR DESCRIPTION
## Summary

Replace the deprecated `datetime.utcnow()` usage in the Trakt collection episode payload builder with a timezone-aware UTC datetime.

## What changes

- Import `timezone` from `datetime`.
- Replace:

  `datetime.utcnow().date()`

  with:

  `datetime.now(timezone.utc).date()`

This preserves the existing UTC-date behavior while avoiding the `DeprecationWarning` emitted by recent Python versions.

## Tests

- The affected Trakt test passes with `DeprecationWarning` promoted to an error.
- Full unit test suite passes locally.
- The previous `datetime.utcnow()` deprecation warning is no longer emitted.