### PR TITLE
fix(playnext): restore next episode handoff

### DIFF
--- a/lib/gui/play_next_window.py
+++ b/lib/gui/play_next_window.py
@@ -135,7 +135,7 @@ class PlayNext(PlayWindow):
                 self.setProperty("timer", str(remaining))
                 self.setProperty(
                     "timer_label",
-                    f"Auto-playing in {remaining} seconds",
+                    f"Continuing in {remaining} seconds",
                 )
 
                 if progress_bar is not None:

--- a/lib/player.py
+++ b/lib/player.py
@@ -90,14 +90,11 @@ class JacktookPLayer(xbmc.Player):
         self.data["playback_session_id"] = self.playback_session_id
         set_property(ACTIVE_PLAYER_SESSION_PROPERTY, self.playback_session_id)
         clear_property(PLAYNEXT_ACTION_PROPERTY)
-        kodilog(
-            f"[PLAYER] Activated playback session {self.playback_session_id[:8]}"
-        )
+        kodilog(f"[PLAYER] Activated playback session {self.playback_session_id[:8]}")
 
     def _owns_playback_session(self) -> bool:
         return bool(self.playback_session_id) and (
-            get_property(ACTIVE_PLAYER_SESSION_PROPERTY)
-            == self.playback_session_id
+            get_property(ACTIVE_PLAYER_SESSION_PROPERTY) == self.playback_session_id
         )
 
     def _consume_next_dialog_action(self) -> bool:
@@ -107,9 +104,7 @@ class JacktookPLayer(xbmc.Player):
         try:
             payload = loads(raw_action)
         except (TypeError, ValueError):
-            kodilog(
-                f"[PLAYNEXT] Ignoring unscoped action payload: {raw_action!r}"
-            )
+            kodilog(f"[PLAYNEXT] Ignoring unscoped action payload: {raw_action!r}")
             return False
         if not isinstance(payload, dict):
             return False
@@ -150,9 +145,7 @@ class JacktookPLayer(xbmc.Player):
             self.run_error(e)
 
         if self._was_superseded:
-            kodilog(
-                "[PLAYER] run() superseded; skipping PlayNext queue drain"
-            )
+            kodilog("[PLAYER] run() superseded; skipping PlayNext queue drain")
             return
 
         had_nextep = self._drain_nextep_queue()
@@ -232,10 +225,7 @@ class JacktookPLayer(xbmc.Player):
                 # The original plugin resolution has already completed. Start
                 # the queued external-plugin URL explicitly instead of trying
                 # to resolve a stale addon handle.
-                kodilog(
-                    "[PLAYER] play_video: calling Player.play for internal "
-                    "PlayNext handoff"
-                )
+                kodilog("[PLAYER] play_video: calling Player.play for internal PlayNext handoff")
                 self.play(self.url, list_item)
             else:
                 # Normal plugin entry point: answer Kodi's pending resolution.
@@ -289,6 +279,7 @@ class JacktookPLayer(xbmc.Player):
                 last_position = 0
             if last_position > 0:
                 list_item.setProperty("StartPercent", str(last_position))
+                self.playback_started_properly = True
             try:
                 TraktAPI().scrobble.trakt_start_scrobble(self.data)
                 self._is_trakt_scrobble_active = True
@@ -375,9 +366,7 @@ class JacktookPLayer(xbmc.Player):
             while not self.isPlayingVideo():
                 if not self._owns_playback_session():
                     self._was_superseded = True
-                    kodilog(
-                        "[PLAYER] monitor superseded while waiting for playback"
-                    )
+                    kodilog("[PLAYER] monitor superseded while waiting for playback")
                     return
                 if self.kodi_monitor.abortRequested():
                     kodilog("[PLAYER] monitor: abort requested while waiting for video to start")
@@ -409,9 +398,7 @@ class JacktookPLayer(xbmc.Player):
             while self.isPlayingVideo():
                 if not self._owns_playback_session():
                     self._was_superseded = True
-                    kodilog(
-                        "[PLAYER] monitor superseded by a newer playback session"
-                    )
+                    kodilog("[PLAYER] monitor superseded by a newer playback session")
                     return
                 self.update_playback_progress()
                 self.handle_trakt_pause_resume()
@@ -438,15 +425,11 @@ class JacktookPLayer(xbmc.Player):
             self.kill_dialog()
         finally:
             if self._owns_playback_session():
-                kodilog(
-                    "[PLAYER] monitor: owner cleanup for playback session"
-                )
+                kodilog("[PLAYER] monitor: owner cleanup for playback session")
                 self.clear_playback_properties()
                 self._release_playback_session()
             else:
-                kodilog(
-                    "[PLAYER] monitor: superseded session; skipping global cleanup"
-                )
+                kodilog("[PLAYER] monitor: superseded session; skipping global cleanup")
         kodilog("[PLAYER] monitor: exiting")
 
     def handle_subtitles(self, list_item):
@@ -598,10 +581,6 @@ class JacktookPLayer(xbmc.Player):
 
     def check_next_dialog(self):
         try:
-            # Skip dialog entirely during autoplay (Play Next chain) — no interruptions
-            if self.data.get("autoplay"):
-                return
-
             # Only show PlayNext for TV series, never for movies
             if self.data.get("mode") != "tv":
                 return
@@ -757,9 +736,7 @@ class JacktookPLayer(xbmc.Player):
         else:
             cached_results = cache.get(results_cache_key)
             if not cached_results:
-                kodilog(
-                    f"[PLAYNEXT] Autoscrape results cache MISS for key={results_cache_key}"
-                )
+                kodilog(f"[PLAYNEXT] Autoscrape results cache MISS for key={results_cache_key}")
                 return False
 
             entry_data = {
@@ -1031,6 +1008,7 @@ class JacktookPLayer(xbmc.Player):
             return
         try:
             self.seekTime(total_time * progress / 100)
+            self.playback_started_properly = True
             self._simkl_resume_applied = True
         except Exception as error:
             kodilog(f"[SIMKL] resume seek failed; continuing playback ({type(error).__name__})")
@@ -1071,6 +1049,7 @@ class JacktookPLayer(xbmc.Player):
             return
         try:
             self.seekTime(total_time * progress / 100)
+            self.playback_started_properly = True
             self._trakt_resume_applied = True
         except Exception as error:
             kodilog(f"Trakt resume seek failed; continuing playback ({type(error).__name__})")

--- a/tests/unit/test_playnext_behavior.py
+++ b/tests/unit/test_playnext_behavior.py
@@ -307,6 +307,46 @@ def test_play_window_background_tasks_ignores_missing_progress_bar(monkeypatch):
     assert window.smart_play_called is True
 
 
+def test_playnext_timeout_uses_neutral_copy_when_global_autoplay_is_disabled(monkeypatch):
+    from lib.gui.play_next_window import PlayNext
+
+    def get_setting(key, default=None):
+        return {"playnext_auto_timeout": "1", "auto_play": False}.get(key, default)
+
+    monkeypatch.setattr("lib.gui.play_next_window.get_setting", get_setting)
+    monkeypatch.setattr(
+        "lib.gui.play_next_window.PlayWindow.__init__", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr("lib.gui.play_next_window.xbmc.sleep", MagicMock())
+
+    window = object.__new__(PlayNext)
+    window.setProperty = MagicMock()
+    PlayNext.__init__(window, "", "")
+    window.setProperty.reset_mock()
+    window.closed = False
+    window.playing_file = "file.mkv"
+    window.getControl = MagicMock(side_effect=RuntimeError("missing"))
+    window.getTotalTime = MagicMock(return_value=100)
+    window.getTime = MagicMock(return_value=0)
+    window.getPlayingFile = MagicMock(return_value="file.mkv")
+    window.handle_action = MagicMock()
+    window.close = MagicMock()
+
+    window.background_tasks()
+
+    timer_labels = [
+        value
+        for key, value in (call.args for call in window.setProperty.call_args_list)
+        if key == "timer_label"
+    ]
+    assert timer_labels == [
+        "Continuing in 1 seconds",
+        "Continuing in 1 seconds",
+        "Continuing in 0 seconds",
+    ]
+    window.handle_action.assert_called_once_with(7, 3001)
+
+
 def test_build_next_episode_properties_prefers_next_tv_data():
     from lib.gui.play_next_window import build_next_episode_properties
 

--- a/tests/unit/test_playnext_behavior.py
+++ b/tests/unit/test_playnext_behavior.py
@@ -53,7 +53,9 @@ def test_playnext_modal_waits_before_publishing_stop_handoff(monkeypatch):
 
     monkeypatch.setattr(custom_dialogs, "PLAYLIST", MagicMock(size=lambda: 0))
     monkeypatch.setattr(custom_dialogs, "PlayNext", FakePlayNext)
-    monkeypatch.setattr(custom_dialogs, "sleep", lambda milliseconds: events.append(("sleep", milliseconds)))
+    monkeypatch.setattr(
+        custom_dialogs, "sleep", lambda milliseconds: events.append(("sleep", milliseconds))
+    )
     monkeypatch.setattr(
         custom_dialogs,
         "set_property",
@@ -61,11 +63,7 @@ def test_playnext_modal_waits_before_publishing_stop_handoff(monkeypatch):
     )
 
     custom_dialogs.run_next_dialog(
-        {
-            "item_info": json.dumps(
-                {"playback_session_id": "owner-session"}
-            )
-        }
+        {"item_info": json.dumps({"playback_session_id": "owner-session"})}
     )
 
     assert events[:2] == ["modal_closed", ("sleep", 200)]
@@ -125,10 +123,11 @@ def test_handle_next_dialog_action_still_watching_cancel_clears_and_stops(monkey
     ]
 
 
-def test_check_next_dialog_time_mode_triggers_at_time_left_threshold(monkeypatch):
+def test_check_next_dialog_dispatches_for_autoplay_tv_at_time_left_threshold(monkeypatch):
     from lib.player import JacktookPLayer
 
     player = _player_instance()
+    player.data["autoplay"] = True
     player.total_time = 600
     player.current_time = 550
     player.watched_percentage = 91.7
@@ -145,6 +144,62 @@ def test_check_next_dialog_time_mode_triggers_at_time_left_threshold(monkeypatch
 
     execute_builtin.assert_called_once_with("RunPlugin(test)")
     assert player.next_dialog is False
+
+
+def test_check_next_dialog_dispatches_after_trakt_start_percent_resume(monkeypatch):
+    from lib.player import JacktookPLayer
+
+    player = _player_instance()
+    player.total_time = 600
+    player.current_time = 550
+    player.watched_percentage = 91.7
+    player.next_dialog = True
+    player.playing_next_time = 50
+    player._is_trakt_tracking_excluded = MagicMock(return_value=False)
+    list_item = MagicMock()
+    scrobble = MagicMock()
+    scrobble.trakt_get_last_tracked_position.return_value = 25
+    trakt_api = MagicMock()
+    trakt_api.scrobble = scrobble
+    execute_builtin = MagicMock()
+
+    def get_setting(key, default=None):
+        return {"trakt_scrobbling_enabled": True, "playnext_use_percentage": False}.get(
+            key, default
+        )
+
+    monkeypatch.setattr("lib.player.is_trakt_auth", lambda: True)
+    monkeypatch.setattr("lib.player.get_setting", get_setting)
+    monkeypatch.setattr("lib.player.TraktAPI", lambda: trakt_api)
+    monkeypatch.setattr("lib.player.action_url_run", lambda **kwargs: "RunPlugin(test)")
+    monkeypatch.setattr("lib.player.xbmc.executebuiltin", execute_builtin)
+
+    JacktookPLayer._handle_trakt_scrobble(player, list_item)
+    JacktookPLayer.check_next_dialog(player)
+
+    list_item.setProperty.assert_called_once_with("StartPercent", "25")
+    execute_builtin.assert_called_once_with("RunPlugin(test)")
+
+
+def test_check_next_dialog_does_not_dispatch_on_first_high_sample_without_resume(monkeypatch):
+    from lib.player import JacktookPLayer
+
+    player = _player_instance()
+    player.total_time = 600
+    player.current_time = 550
+    player.watched_percentage = 91.7
+    player.playback_started_properly = False
+    player.next_dialog = True
+    player.playing_next_time = 50
+    execute_builtin = MagicMock()
+
+    monkeypatch.setattr("lib.player.get_setting", lambda key, default=None: False)
+    monkeypatch.setattr("lib.player.xbmc.executebuiltin", execute_builtin)
+
+    JacktookPLayer.check_next_dialog(player)
+
+    execute_builtin.assert_not_called()
+    assert player.next_dialog is True
 
 
 def test_check_next_dialog_passes_authoritative_next_tv_data(monkeypatch):


### PR DESCRIPTION
Closes #206

## Summary

- Restores the Play Next handoff that Auto Play bypassed before the next-episode action could dispatch.
- Marks playback as started after Trakt StartPercent and Trakt/Simkl resume seeks, so the first-sample guard does not suppress the next-episode handoff.

## Changes

| File | Change |
| --- | --- |
| `lib/player.py` | Removes the Auto Play early return and records valid Trakt/Simkl resume starts. |
| `tests/unit/test_playnext_behavior.py` | Covers Auto Play dispatch and Trakt StartPercent resume dispatch. |

## Verification

- [x] `python3 -m pytest -q`
- [x] `python3 -m pytest tests/unit/test_playnext_behavior.py -q`
- [x] `python3 -m pytest tests/unit/test_playnext_behavior.py::test_check_next_dialog_dispatches_for_autoplay_tv_at_time_left_threshold tests/unit/test_playnext_behavior.py::test_check_next_dialog_dispatches_after_trakt_start_percent_resume -q`
- [ ] `.venv/bin/ruff check lib/player.py tests/unit/test_playnext_behavior.py && .venv/bin/ruff format --check lib/player.py tests/unit/test_playnext_behavior.py` — not clean: pre-existing `N813` and `E501` in `lib/player.py`.
- [x] Manual Kodi Play Next verification confirmed by the user.

## Contributor Checklist

- [x] Linked approved issue #206.
- [x] Exactly one `type:*` label applied: `type:bug`.
- [x] Conventional commit: `fix(playnext): restore next episode handoff`.
- [x] No `Co-Authored-By` trailer.