### PR TITLE
Fix: auto_play falls back to source select instead of failing silently

### DIFF
--- a/lib/search.py
+++ b/lib/search.py
@@ -790,21 +790,22 @@ def run_search_entry(params: dict):
     force_select = params.get("force_select", False)
     autoplay_context = params.get("autoplay_context")
 
+    # Fixed: if Auto-Play is enabled but fails (most commonly because
+    # results exist but none match the preferred auto_play_quality), fall
+    # back to the manual source-select screen instead of just cancelling
+    # playback. The user still gets to pick a source manually rather than
+    # a bare "no sources" failure when sources did in fact exist.
     if auto_play_enabled() and not force_select:
-        if (
-            not auto_play(
-                final_results,
-                ids,
-                tv_data,
-                mode,
-                preferred_group,
-                autoplay_context=autoplay_context,
-                playback_context=playback_resume,
-            )
-            and not skip_cancel
+        if auto_play(
+            final_results,
+            ids,
+            tv_data,
+            mode,
+            preferred_group,
+            autoplay_context=autoplay_context,
+            playback_context=playback_resume,
         ):
-            cancel_playback()
-        return
+            return
 
     if (
         not show_source_select(

--- a/lib/search.py
+++ b/lib/search.py
@@ -795,7 +795,8 @@ def run_search_entry(params: dict):
     # back to the manual source-select screen instead of just cancelling
     # playback. The user still gets to pick a source manually rather than
     # a bare "no sources" failure when sources did in fact exist.
-    if auto_play_enabled() and not force_select:
+    autoplay_attempted = auto_play_enabled() and not force_select
+    if autoplay_attempted:
         if auto_play(
             final_results,
             ids,
@@ -819,6 +820,7 @@ def run_search_entry(params: dict):
             direct,
             autoplay_context=autoplay_context,
             playback_context=playback_resume,
+            rejection_already_notified=autoplay_attempted,
         )
         and not skip_cancel
     ):
@@ -1685,6 +1687,7 @@ def show_source_select(
     direct: bool = False,
     autoplay_context: Optional[str] = None,
     playback_context: Optional[dict] = None,
+    rejection_already_notified: bool = False,
 ) -> bool:
     rejection_reasons = []
     results = _prepare_stremio_results(
@@ -1693,7 +1696,7 @@ def show_source_select(
         rejection_reasons=rejection_reasons,
     )
     if not results:
-        if rejection_reasons:
+        if rejection_reasons and not rejection_already_notified:
             notification(rejection_reasons[0])
         return False
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from lib.api.tmdbv3api.as_obj import AsObj
+from lib.clients.stremio.playback import StremioPlaybackError
+from lib.domain.torrent import TorrentStream
 from lib.search import (
     SearchCancelled,
     SearchVariant,
@@ -433,6 +435,106 @@ def test_auto_play_skips_metadata_hydration_for_direct_sources():
         assert search.auto_play([source], {"tmdb_id": "123"}, {}, "movies") is True
 
     build_metadata.assert_not_called()
+
+
+def test_run_search_entry_does_not_repeat_stremio_rejection_after_autoplay_fallback():
+    from lib import search
+
+    source = TorrentStream(
+        title="Unsupported source",
+        addonKey="org.example.addon|https://example.com",
+        stremioMetadata={"externalUrl": "https://external.example/watch"},
+    )
+    notifications = []
+    params = {
+        "query": "Movie",
+        "mode": "movies",
+        "media_type": "movies",
+        "ids": json.dumps({"imdb_id": "tt123"}),
+    }
+
+    with patch("lib.search._handle_super_quick_play", return_value=False), patch(
+        "lib.search.search_client", return_value=[source]
+    ), patch("lib.search._process_search_results", return_value=[source]), patch(
+        "lib.search.set_content_type"
+    ), patch("lib.search.set_watched_title"), patch(
+        "lib.search.auto_play_enabled", return_value=True
+    ), patch("lib.search.notification", side_effect=notifications.append), patch(
+        "lib.search.show_source_select", wraps=search.show_source_select
+    ) as show_source_select_mock, patch("lib.search.source_select") as source_select_mock, patch(
+        "lib.search.cancel_playback"
+    ) as cancel_playback_mock:
+        run_search_entry(params)
+
+    assert notifications == [
+        "External web pages are not playable sources.",
+        "No suitable source found for auto play.",
+    ]
+    assert show_source_select_mock.call_args.kwargs["rejection_already_notified"] is True
+    source_select_mock.assert_not_called()
+    cancel_playback_mock.assert_called_once_with()
+
+
+def test_run_search_entry_falls_back_to_source_selection_after_quality_failure():
+    source = _auto_play_source(IndexerType.TORRENT)
+    params = {
+        "query": "Movie",
+        "mode": "movies",
+        "media_type": "movies",
+        "ids": json.dumps({"imdb_id": "tt123"}),
+    }
+
+    with patch("lib.search._handle_super_quick_play", return_value=False), patch(
+        "lib.search.search_client", return_value=[source]
+    ), patch("lib.search._process_search_results", return_value=[source]), patch(
+        "lib.search.set_content_type"
+    ), patch("lib.search.set_watched_title"), patch(
+        "lib.search.auto_play_enabled", return_value=True
+    ), patch("lib.search.get_setting", return_value="2160p"), patch(
+        "lib.search.build_media_metadata", return_value={}
+    ), patch("lib.search.notification") as notification_mock, patch(
+        "lib.search.source_select", return_value=True
+    ) as source_select_mock, patch("lib.search.cancel_playback") as cancel_playback_mock:
+        run_search_entry(params)
+
+    notification_mock.assert_called_once_with("No sources found with the preferred quality.")
+    assert source_select_mock.call_args.kwargs["sources"] == [source]
+    cancel_playback_mock.assert_not_called()
+
+
+def test_run_search_entry_falls_back_to_source_selection_after_resolution_failure():
+    source = TorrentStream(
+        title="Resolvable source",
+        quality="1080p",
+        addonKey="org.example.addon|https://example.com",
+        stremioMetadata={"url": "https://media.example/movie.mkv"},
+    )
+    params = {
+        "query": "Movie",
+        "mode": "movies",
+        "media_type": "movies",
+        "ids": json.dumps({"imdb_id": "tt123"}),
+    }
+
+    with patch("lib.search._handle_super_quick_play", return_value=False), patch(
+        "lib.search.search_client", return_value=[source]
+    ), patch("lib.search._process_search_results", return_value=[source]), patch(
+        "lib.search.set_content_type"
+    ), patch("lib.search.set_watched_title"), patch(
+        "lib.search.auto_play_enabled", return_value=True
+    ), patch("lib.search.get_setting", return_value="1080p"), patch(
+        "lib.search._resolve_stremio_source",
+        side_effect=StremioPlaybackError("resolution_failed", "Unable to resolve source."),
+    ), patch("lib.search.build_media_metadata", return_value={}), patch(
+        "lib.search.notification"
+    ) as notification_mock, patch("lib.search.source_select", return_value=True) as source_select_mock, patch(
+        "lib.search.cancel_playback"
+    ) as cancel_playback_mock:
+        run_search_entry(params)
+
+    notification_mock.assert_called_once_with("Unable to resolve source.")
+    assert source_select_mock.call_args.kwargs["sources"] == [source]
+    cancel_playback_mock.assert_not_called()
 
 
 def test_run_search_entry_source_select_cancel_skipped_on_back():


### PR DESCRIPTION
When Auto-Play is enabled (Settings > Playback > Auto-Play), if search results are found but none match the configured auto_play_quality (e.g. quality is set to 1080p but only 720p or 2160p sources exist for that title/episode), auto_play() returns False and playback is simply cancelled - the user sees "No sources found with the preferred quality" and nothing else happens.

This is misleading: sources DID exist, just not in the preferred quality. The user has no way to pick one manually, even though the manual source-select screen (show_source_select) already exists and is used in every other case.

This is likely one of the most common causes of "no sources found" reports for users who have Auto-Play enabled, since many titles or episodes only have a single available quality that may not match the configured preference.

Fix: when auto_play() fails for any reason, fall through to the existing show_source_select() call instead of unconditionally calling cancel_playback(). This preserves the current behaviour when auto_play succeeds (early return, same as before), but now gives the user the chance to pick a source manually whenever auto_play can't, instead of a bare failure.