### PR TITLE
Fix: resolve missing imdb_id and force rescrape when resuming Trakt/S…

### DIFF
--- a/lib/navigation.py
+++ b/lib/navigation.py
@@ -1502,7 +1502,7 @@ def simkl_update_history(params):
 def simkl_resume(params):
     from lib.search import run_search_entry
 
-    run_search_entry(params)
+    run_search_entry(_prepare_resume_search_params(params))
 
 
 def simkl_discard_playback(params):
@@ -1520,7 +1520,51 @@ def trakt_continue_watching(params):
 def trakt_resume(params):
     from lib.search import run_search_entry
 
-    run_search_entry(params)
+    run_search_entry(_prepare_resume_search_params(params))
+
+
+def _prepare_resume_search_params(params):
+    """Prepare params coming from a Trakt/Simkl "continue watching" resume
+    for a reliable search.
+
+    Two problems fixed here:
+
+    1. The playback items built by TraktScrobble.get_playback() and
+       SimklClient.get_playback() never set "rescrape", so resuming an
+       episode/movie could silently return a stale (possibly empty)
+       cached search result instead of searching again.
+    2. Those same items only carry a bare {"tmdb_id": ...} in "ids" -
+       no imdb_id/tvdb_id at all. Sources that match by IMDB id (e.g.
+       Stremio addons like Torrentio) then find nothing, even though a
+       normal search for the same title works fine. We resolve the
+       missing ids from TMDB before searching, same as rescrape_tmdb_media
+       already does for the regular "Scrape again" context menu action.
+    """
+    import json
+
+    from lib.utils.general.utils import safe_json_loads
+
+    params = dict(params)
+    ids = safe_json_loads(params.get("ids")) or {}
+
+    if ids.get("tmdb_id") and not ids.get("imdb_id"):
+        try:
+            from lib.clients.tmdb.tmdb import TmdbClient
+
+            mode = params.get("mode", "")
+            media_type = params.get("media_type", "")
+            tmdb_obj = TmdbClient._get_tmdb_metadata(mode, media_type, ids["tmdb_id"])
+            external_ids = (tmdb_obj or {}).get("external_ids") or {}
+            if external_ids.get("imdb_id"):
+                ids["imdb_id"] = external_ids["imdb_id"]
+            if external_ids.get("tvdb_id"):
+                ids["tvdb_id"] = external_ids["tvdb_id"]
+        except Exception as error:
+            kodilog(f"resume: failed to resolve imdb/tvdb id from tmdb_id: {error}")
+
+    params["ids"] = json.dumps(ids)
+    params["rescrape"] = True
+    return params
 
 
 def trakt_discard_playback(params):

--- a/tests/unit/test_simkl_continue_watching.py
+++ b/tests/unit/test_simkl_continue_watching.py
@@ -1,4 +1,7 @@
+import json
 from unittest.mock import MagicMock
+
+import pytest
 
 from lib.utils.general.items_menus import (
     movie_items,
@@ -189,13 +192,68 @@ def test_discard_refreshes_only_after_successful_delete(monkeypatch):
     refresh.assert_called_once_with("Container.Refresh")
 
 
-def test_simkl_resume_delegates_to_standard_source_search(monkeypatch):
+def test_simkl_resume_resolves_external_ids_and_forces_rescrape(monkeypatch):
     from lib import navigation
 
     run_search_entry = MagicMock()
+    tmdb_metadata = MagicMock(
+        return_value={"external_ids": {"imdb_id": "tt7654321", "tvdb_id": 56789}}
+    )
     monkeypatch.setattr("lib.search.run_search_entry", run_search_entry)
-    params = {"query": "Movie", "simkl_session_id": "9", "simkl_resume_progress": "50"}
+    monkeypatch.setattr(navigation.TmdbClient, "_get_tmdb_metadata", tmdb_metadata)
+    params = {
+        "query": "Movie",
+        "mode": "movies",
+        "media_type": "movie",
+        "ids": json.dumps({"tmdb_id": 123}),
+        "simkl_session_id": "9",
+        "simkl_resume_progress": "50",
+    }
 
     navigation.simkl_resume(params)
 
-    run_search_entry.assert_called_once_with(params)
+    tmdb_metadata.assert_called_once_with("movies", "movie", 123)
+    run_search_entry.assert_called_once()
+    search_params = run_search_entry.call_args.args[0]
+    assert search_params["rescrape"] is True
+    assert json.loads(search_params["ids"]) == {
+        "tmdb_id": 123,
+        "imdb_id": "tt7654321",
+        "tvdb_id": 56789,
+    }
+
+
+@pytest.mark.parametrize(
+    "tmdb_response",
+    [None, RuntimeError("TMDB unavailable")],
+    ids=["metadata unavailable", "TMDB request fails"],
+)
+def test_simkl_resume_continues_search_when_tmdb_metadata_is_unavailable(
+    monkeypatch, tmdb_response
+):
+    from lib import navigation
+
+    run_search_entry = MagicMock()
+    tmdb_metadata = MagicMock()
+    if isinstance(tmdb_response, Exception):
+        tmdb_metadata.side_effect = tmdb_response
+    else:
+        tmdb_metadata.return_value = tmdb_response
+    monkeypatch.setattr("lib.search.run_search_entry", run_search_entry)
+    monkeypatch.setattr(navigation.TmdbClient, "_get_tmdb_metadata", tmdb_metadata)
+    params = {
+        "query": "Movie",
+        "mode": "movies",
+        "media_type": "movie",
+        "ids": json.dumps({"tmdb_id": 123}),
+        "simkl_session_id": "9",
+        "simkl_resume_progress": "50",
+    }
+
+    navigation.simkl_resume(params)
+
+    run_search_entry.assert_called_once()
+    search_params = run_search_entry.call_args.args[0]
+    assert search_params["query"] == "Movie"
+    assert search_params["rescrape"] is True
+    assert json.loads(search_params["ids"]) == {"tmdb_id": 123}

--- a/tests/unit/test_trakt_continue_watching.py
+++ b/tests/unit/test_trakt_continue_watching.py
@@ -1,4 +1,7 @@
+import json
 from unittest.mock import MagicMock
+
+import pytest
 
 from lib.api.trakt.trakt import TraktScrobble
 from lib.utils.general.items_menus import root_menu_items
@@ -261,13 +264,68 @@ def test_trakt_discard_refreshes_only_after_successful_delete(monkeypatch):
     refresh.assert_called_once_with("Container.Refresh")
 
 
-def test_trakt_resume_delegates_to_standard_source_search(monkeypatch):
+def test_trakt_resume_resolves_external_ids_and_forces_rescrape(monkeypatch):
     from lib import navigation
 
     run_search_entry = MagicMock()
+    tmdb_metadata = MagicMock(
+        return_value={"external_ids": {"imdb_id": "tt1234567", "tvdb_id": 98765}}
+    )
     monkeypatch.setattr("lib.search.run_search_entry", run_search_entry)
-    params = {"query": "Movie", "trakt_playback_id": "9", "trakt_resume_progress": "50"}
+    monkeypatch.setattr(navigation.TmdbClient, "_get_tmdb_metadata", tmdb_metadata)
+    params = {
+        "query": "Movie",
+        "mode": "movies",
+        "media_type": "movie",
+        "ids": json.dumps({"tmdb_id": 123}),
+        "trakt_playback_id": "9",
+        "trakt_resume_progress": "50",
+    }
 
     navigation.trakt_resume(params)
 
-    run_search_entry.assert_called_once_with(params)
+    tmdb_metadata.assert_called_once_with("movies", "movie", 123)
+    run_search_entry.assert_called_once()
+    search_params = run_search_entry.call_args.args[0]
+    assert search_params["rescrape"] is True
+    assert json.loads(search_params["ids"]) == {
+        "tmdb_id": 123,
+        "imdb_id": "tt1234567",
+        "tvdb_id": 98765,
+    }
+
+
+@pytest.mark.parametrize(
+    "tmdb_response",
+    [None, RuntimeError("TMDB unavailable")],
+    ids=["metadata unavailable", "TMDB request fails"],
+)
+def test_trakt_resume_continues_search_when_tmdb_metadata_is_unavailable(
+    monkeypatch, tmdb_response
+):
+    from lib import navigation
+
+    run_search_entry = MagicMock()
+    tmdb_metadata = MagicMock()
+    if isinstance(tmdb_response, Exception):
+        tmdb_metadata.side_effect = tmdb_response
+    else:
+        tmdb_metadata.return_value = tmdb_response
+    monkeypatch.setattr("lib.search.run_search_entry", run_search_entry)
+    monkeypatch.setattr(navigation.TmdbClient, "_get_tmdb_metadata", tmdb_metadata)
+    params = {
+        "query": "Movie",
+        "mode": "movies",
+        "media_type": "movie",
+        "ids": json.dumps({"tmdb_id": 123}),
+        "trakt_playback_id": "9",
+        "trakt_resume_progress": "50",
+    }
+
+    navigation.trakt_resume(params)
+
+    run_search_entry.assert_called_once()
+    search_params = run_search_entry.call_args.args[0]
+    assert search_params["query"] == "Movie"
+    assert search_params["rescrape"] is True
+    assert json.loads(search_params["ids"]) == {"tmdb_id": 123}


### PR DESCRIPTION
…imkl playback

## Problem

The "Continue Watching" items built by TraktScrobble.get_playback() and SimklClient.get_playback() only carry a bare
"ids": {"tmdb_id": ...} with no imdb_id or tvdb_id at all, and the resulting search is never given "rescrape": True.

This causes two compounding failures when resuming an in-progress movie or episode from Trakt or Simkl:

1. Sources that match by IMDB id (e.g. Stremio addons such as Torrentio) cannot find anything at all, since they have no imdb_id to search with - even though a normal search for the exact same title works fine and does find sources.
2. Without "rescrape": True, a previous empty/stale cached search result for that title (if any) is returned as-is instead of searching again.

In practice this means resuming from Trakt/Simkl "Continue Watching" very frequently reports "no sources found", even for titles/episodes that are trivially found via a normal search or via Scrape again.

## Fix

Both trakt_resume() and simkl_resume() now go through a shared _prepare_resume_search_params() helper that:

- Resolves the missing imdb_id/tvdb_id from TMDB before searching, using the same TmdbClient._get_tmdb_metadata() call already used by rescrape_tmdb_media() for the regular "Scrape again" context menu action.
- Forces rescrape=True, so a stale/empty cached result is never silently reused.

## Testing

Reproduced and confirmed with an A/B/A test on a real device (Stremio source only, Torrentio): with the original navigation.py, resuming several previously-watched and brand new episodes/movies from both Trakt and Simkl Continue Watching consistently failed with "no sources found". Swapping in this fixed navigation.py (no other files changed) immediately fixed playback for the same titles - reverting to the original file reproduced the failure again, and reapplying the fix resolved it again.