### PR TITLE
Fix: super quick play must not reclassify or override an already-resolved / explicit source selection

### DIFF
--- a/lib/search.py
+++ b/lib/search.py
@@ -541,12 +541,6 @@ def _resolve_cached_source(source: Any, params: Mapping[str, Any]):
 
 def _handle_super_quick_play(params: dict) -> bool:
     if params.get("force_select"):
-        # run_search_entry() calls _handle_super_quick_play() before it
-        # even reads "force_select" from params, so an explicit "Source
-        # Select" / "Scrape again" request (which sets force_select=True)
-        # was being silently overridden by a stale cached entry here -
-        # the user asked to choose a source and got a cached one replayed
-        # instead, without ever seeing the source list.
         kodilog("Super quick play: force_select requested, skipping cached shortcut")
         return False
 
@@ -572,28 +566,6 @@ def _handle_super_quick_play(params: dict) -> bool:
         return False
 
     def play_cached_source() -> bool:
-        # `cached_torrent` can be one of two shapes here:
-        #
-        # 1. An already fully-resolved playback_info dict, written by
-        #    resolver_window.py's _cache_playback_info() right after a
-        #    source was picked and resolved once. Its "url" is a
-        #    player-specific locator such as
-        #    plugin://plugin.video.jacktorr/play_magnet?..., not a raw
-        #    Stremio stream candidate.
-        #
-        # 2. A raw/unresolved Stremio source (legacy cache format) that
-        #    still needs to go through classification/resolution, same
-        #    as a fresh search result would.
-        #
-        # Re-running (1) through _resolve_cached_source() re-classifies
-        # an already-resolved player locator as if it were an unresolved
-        # candidate. The classifier correctly rejects it - it's neither
-        # a valid magnet/infoHash nor a plain http(s) URL - raising
-        # StremioPlaybackError(code="malformed_locator"): "The direct
-        # source locator is malformed", even though the cached data was
-        # perfectly playable as-is. So: if it's already a resolved
-        # player-plugin locator, play it directly; otherwise resolve it
-        # as before.
         def play(data: dict) -> None:
             for key in (
                 "simkl_session_id",

--- a/lib/search.py
+++ b/lib/search.py
@@ -562,6 +562,45 @@ def _handle_super_quick_play(params: dict) -> bool:
         return False
 
     def play_cached_source() -> bool:
+        # `cached_torrent` can be one of two shapes here:
+        #
+        # 1. An already fully-resolved playback_info dict, written by
+        #    resolver_window.py's _cache_playback_info() right after a
+        #    source was picked and resolved once. Its "url" is a
+        #    player-specific locator such as
+        #    plugin://plugin.video.jacktorr/play_magnet?..., not a raw
+        #    Stremio stream candidate.
+        #
+        # 2. A raw/unresolved Stremio source (legacy cache format) that
+        #    still needs to go through classification/resolution, same
+        #    as a fresh search result would.
+        #
+        # Re-running (1) through _resolve_cached_source() re-classifies
+        # an already-resolved player locator as if it were an unresolved
+        # candidate. The classifier correctly rejects it - it's neither
+        # a valid magnet/infoHash nor a plain http(s) URL - raising
+        # StremioPlaybackError(code="malformed_locator"): "The direct
+        # source locator is malformed", even though the cached data was
+        # perfectly playable as-is. So: if it's already a resolved
+        # player-plugin locator, play it directly; otherwise resolve it
+        # as before.
+        def play(data: dict) -> None:
+            for key in (
+                "simkl_session_id",
+                "simkl_resume_progress",
+                "trakt_playback_id",
+                "trakt_resume_progress",
+            ):
+                if key in params:
+                    data[key] = params[key]
+            player = JacktookPLayer()
+            player.run(data=data)
+
+        cached_url = cached_torrent.get("url") if isinstance(cached_torrent, Mapping) else None
+        if isinstance(cached_url, str) and cached_url.startswith("plugin://"):
+            play(dict(cached_torrent))
+            return True
+
         try:
             playback_info = _resolve_cached_source(cached_torrent, params)
         except StremioPlaybackError as error:
@@ -579,17 +618,7 @@ def _handle_super_quick_play(params: dict) -> bool:
             notification(translation(90144))
             return True
 
-        for key in (
-            "simkl_session_id",
-            "simkl_resume_progress",
-            "trakt_playback_id",
-            "trakt_resume_progress",
-        ):
-            if key in params:
-                playback_info[key] = params[key]
-
-        player = JacktookPLayer()
-        player.run(data=playback_info)
+        play(playback_info)
         return True
 
     if get_setting("silent_resume", False):

--- a/lib/search.py
+++ b/lib/search.py
@@ -540,6 +540,16 @@ def _resolve_cached_source(source: Any, params: Mapping[str, Any]):
 
 
 def _handle_super_quick_play(params: dict) -> bool:
+    if params.get("force_select"):
+        # run_search_entry() calls _handle_super_quick_play() before it
+        # even reads "force_select" from params, so an explicit "Source
+        # Select" / "Scrape again" request (which sets force_select=True)
+        # was being silently overridden by a stale cached entry here -
+        # the user asked to choose a source and got a cached one replayed
+        # instead, without ever seeing the source list.
+        kodilog("Super quick play: force_select requested, skipping cached shortcut")
+        return False
+
     if not get_setting("super_quick_play", False):
         kodilog("Super quick play disabled")
         return False

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -92,7 +92,6 @@ def test_super_quick_play_preserves_simkl_resume_metadata():
     assert played_data["url"] == cached_playback_info["url"]
     assert played_data["simkl_session_id"] == "9"
     assert played_data["simkl_resume_progress"] == "50"
-    # The original cached entry itself must not be mutated in place.
     assert "simkl_session_id" not in cached_playback_info
 
 
@@ -121,13 +120,6 @@ def test_super_quick_play_preserves_trakt_resume_metadata():
 
 
 def test_super_quick_play_plays_resolved_plugin_locator_without_reclassifying():
-    """A cached entry whose "url" is already a player-plugin locator (e.g.
-    written by resolver_window.py after a source was resolved once) must
-    be played directly, not re-run through the Stremio candidate
-    classifier - doing so previously raised a spurious
-    StremioPlaybackError(code="malformed_locator") for perfectly playable
-    cached data.
-    """
     params = {"ids": json.dumps({"tmdb_id": 123})}
     cached_playback_info = {
         "url": "plugin://plugin.video.jacktorr/play_magnet?magnet=abc",
@@ -151,13 +143,6 @@ def test_super_quick_play_plays_resolved_plugin_locator_without_reclassifying():
 
 
 def test_super_quick_play_skips_cache_when_force_select_requested():
-    """An explicit "Source Select" / "Scrape again" request (force_select
-    in params) must always bypass the Super Quick Play cached shortcut,
-    even when a cached entry exists and Super Quick Play / silent resume
-    are enabled - the user explicitly asked to choose a source and must
-    reach the normal search + source-select flow, not have a cached
-    (possibly stale) entry replayed silently.
-    """
     params = {"ids": json.dumps({"tmdb_id": 123}), "force_select": True}
     cache_get = MagicMock(return_value={"url": "plugin://plugin.video.jacktorr/play_magnet?magnet=abc"})
     player = MagicMock()

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -77,20 +77,23 @@ def test_super_quick_play_preserves_simkl_resume_metadata():
         "simkl_session_id": "9",
         "simkl_resume_progress": "50",
     }
-    playback_info = {"url": "https://stream.example/video"}
+    cached_playback_info = {"url": "plugin://plugin.video.jacktorr/play_magnet?magnet=x"}
     player = MagicMock()
 
     with patch(
         "lib.search.get_setting",
         side_effect=lambda key, default=None: key in {"super_quick_play", "silent_resume"},
-    ), patch("lib.search.cache.get", return_value=MagicMock()), patch(
-        "lib.search._resolve_cached_source", return_value=playback_info
-    ), patch("lib.search.JacktookPLayer", return_value=player):
+    ), patch("lib.search.cache.get", return_value=cached_playback_info), patch(
+        "lib.search.JacktookPLayer", return_value=player
+    ):
         assert _handle_super_quick_play(params) is True
 
-    assert playback_info["simkl_session_id"] == "9"
-    assert playback_info["simkl_resume_progress"] == "50"
-    player.run.assert_called_once_with(data=playback_info)
+    played_data = player.run.call_args.kwargs["data"]
+    assert played_data["url"] == cached_playback_info["url"]
+    assert played_data["simkl_session_id"] == "9"
+    assert played_data["simkl_resume_progress"] == "50"
+    # The original cached entry itself must not be mutated in place.
+    assert "simkl_session_id" not in cached_playback_info
 
 
 def test_super_quick_play_preserves_trakt_resume_metadata():
@@ -99,20 +102,52 @@ def test_super_quick_play_preserves_trakt_resume_metadata():
         "trakt_playback_id": "9",
         "trakt_resume_progress": "50",
     }
-    playback_info = {"url": "https://stream.example/video"}
+    cached_playback_info = {"url": "plugin://plugin.video.jacktorr/play_magnet?magnet=x"}
     player = MagicMock()
 
     with patch(
         "lib.search.get_setting",
         side_effect=lambda key, default=None: key in {"super_quick_play", "silent_resume"},
-    ), patch("lib.search.cache.get", return_value=MagicMock()), patch(
-        "lib.search._resolve_cached_source", return_value=playback_info
-    ), patch("lib.search.JacktookPLayer", return_value=player):
+    ), patch("lib.search.cache.get", return_value=cached_playback_info), patch(
+        "lib.search.JacktookPLayer", return_value=player
+    ):
         assert _handle_super_quick_play(params) is True
 
-    assert playback_info["trakt_playback_id"] == "9"
-    assert playback_info["trakt_resume_progress"] == "50"
-    player.run.assert_called_once_with(data=playback_info)
+    played_data = player.run.call_args.kwargs["data"]
+    assert played_data["url"] == cached_playback_info["url"]
+    assert played_data["trakt_playback_id"] == "9"
+    assert played_data["trakt_resume_progress"] == "50"
+    assert "trakt_playback_id" not in cached_playback_info
+
+
+def test_super_quick_play_plays_resolved_plugin_locator_without_reclassifying():
+    """A cached entry whose "url" is already a player-plugin locator (e.g.
+    written by resolver_window.py after a source was resolved once) must
+    be played directly, not re-run through the Stremio candidate
+    classifier - doing so previously raised a spurious
+    StremioPlaybackError(code="malformed_locator") for perfectly playable
+    cached data.
+    """
+    params = {"ids": json.dumps({"tmdb_id": 123})}
+    cached_playback_info = {
+        "url": "plugin://plugin.video.jacktorr/play_magnet?magnet=abc",
+        "magnet": "magnet:?xt=urn:btih:abc",
+        "title": "Cached episode",
+    }
+    player = MagicMock()
+
+    with patch(
+        "lib.search.get_setting",
+        side_effect=lambda key, default=None: key in {"super_quick_play", "silent_resume"},
+    ), patch("lib.search.cache.get", return_value=cached_playback_info), patch(
+        "lib.search._resolve_cached_source"
+    ) as resolve_cached_source, patch("lib.search.JacktookPLayer", return_value=player):
+        assert _handle_super_quick_play(params) is True
+
+    resolve_cached_source.assert_not_called()
+    played_data = player.run.call_args.kwargs["data"]
+    assert played_data["url"] == cached_playback_info["url"]
+    assert played_data["magnet"] == cached_playback_info["magnet"]
 
 
 def test_run_search_entry_forwards_trakt_resume_to_source_selection():

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -150,6 +150,30 @@ def test_super_quick_play_plays_resolved_plugin_locator_without_reclassifying():
     assert played_data["magnet"] == cached_playback_info["magnet"]
 
 
+def test_super_quick_play_skips_cache_when_force_select_requested():
+    """An explicit "Source Select" / "Scrape again" request (force_select
+    in params) must always bypass the Super Quick Play cached shortcut,
+    even when a cached entry exists and Super Quick Play / silent resume
+    are enabled - the user explicitly asked to choose a source and must
+    reach the normal search + source-select flow, not have a cached
+    (possibly stale) entry replayed silently.
+    """
+    params = {"ids": json.dumps({"tmdb_id": 123}), "force_select": True}
+    cache_get = MagicMock(return_value={"url": "plugin://plugin.video.jacktorr/play_magnet?magnet=abc"})
+    player = MagicMock()
+
+    with patch(
+        "lib.search.get_setting",
+        side_effect=lambda key, default=None: key in {"super_quick_play", "silent_resume"},
+    ), patch("lib.search.cache.get", cache_get), patch(
+        "lib.search.JacktookPLayer", return_value=player
+    ):
+        assert _handle_super_quick_play(params) is False
+
+    cache_get.assert_not_called()
+    player.run.assert_not_called()
+
+
 def test_run_search_entry_forwards_trakt_resume_to_source_selection():
     params = {
         "query": "Movie",


### PR DESCRIPTION
## Problem

`_handle_super_quick_play()` (used by both the "Super Quick Play" setting and the "Do you want to play last watched?" dialog) had two related bugs, both traced to a real device via debug logs:

### 1. `malformed_locator` on cached playback (commit 1)

`resolver_window.py`'s `_cache_playback_info()` caches the *fully-resolved* playback_info dict for reuse (Settings > Super Quick Play). For a torrent-client integration such as Jacktorr, that dict's `"url"` is already a player-specific locator, e.g.:

    plugin://plugin.video.jacktorr/play_magnet?magnet=...

`_handle_super_quick_play()` retrieves this cached entry and passes it to `_resolve_cached_source()`, which runs it through the Stremio candidate classifier as if it were a *raw, unresolved* source. The classifier correctly rejects it there — a `plugin://` locator is neither a valid magnet/infoHash nor a plain http(s) URL — raising `StremioPlaybackError(code="malformed_locator")`:

    stremio_playback_error phase=super_quick_play code=malformed_locator

Kodi then reports "The direct source locator is malformed" and playback fails, even though a perfectly valid, playable source was found moments earlier in the very same session. This is unrelated to how long the entry has been cached — reproduced within the same playback session, right after Auto-Play picked a source for an episode never played before.

### 2. Explicit "Source Select" silently overridden by stale cache (commit 2)

`run_search_entry()` calls `_handle_super_quick_play(params)` **before** it even reads `params.get("force_select")`. This means an explicit "Source Select" / "Scrape again" request (both set `force_select=True`) was silently overridden whenever a cached Super Quick Play entry existed: instead of reaching the normal search and seeing the source list they explicitly asked for, the user got a cached (possibly stale) entry replayed instead, with no indication anything was skipped.

Confirmed on a real device: with a cached entry present, choosing the "Escolher" (force_select) player never showed the source list — a torrent silently started downloading in TorrServer without the user ever picking a source.

This bug already existed before fix #1 in this PR. It was previously less visible because the cached entry's reclassification usually failed loudly; now that a resolved `plugin://` locator is replayed directly, the override became silent and easy to miss.

## Fix

**Commit 1:** `_handle_super_quick_play()` now checks whether the cached entry's `"url"` is already a `plugin://` locator. If so, it is played directly without going through `_resolve_cached_source()` again. Cached entries that are still a raw/unresolved Stremio source (the legacy cache shape some existing tests cover) keep going through the existing resolution path unchanged.

**Commit 2:** `_handle_super_quick_play()` now returns `False` immediately when `force_select` is set in params, before even checking the `super_quick_play` setting or touching the cache — guaranteeing the normal search/source-select flow always runs when the user explicitly asked to choose. `rescrape` is deliberately **not** included in this check: it only affects whether the search results cache is bypassed and is sent on virtually every call (including plain autoplay), so gating on it too would effectively disable Super Quick Play altogether.

## Testing

- Existing legacy-cache tests in `test_stremio_playback_fidelity.py` continue to pass unmodified — the raw/unresolved cache path is untouched.
- Updated the two existing `super_quick_play` tests in `test_search.py` to assert against the data actually handed to the player.
- Added `test_super_quick_play_plays_resolved_plugin_locator_without_reclassifying` and `test_super_quick_play_skips_cache_when_force_select_requested`, each covering one of the two bugs directly.
- Full suite: 1529 passed, 0 failed (rebased against latest `main`, including the recent `#209`/`#210` follow-up work).